### PR TITLE
fix: change prepare to prepublishOnly to prevent recursive install in monorepos

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "tsc": "tsc",
     "tslint-check": "tslint-config-prettier-check ./tslint.json",
-    "prepare": "npm run clean && npm run build",
+    "prepublishOnly": "npm run clean && npm run build",
     "prettier": "if test -z $CI; then prettier --write \"./{src,test}/**/*.{ts,js}\"; fi"
   },
   "license": "MIT",


### PR DESCRIPTION
`prepare` runs on every `npm/pnpm install`, including when installed from a GitHub tarball. In pnpm monorepos, this triggers a recursive install loop because the nested install for devDependencies walks up the directory tree, discovers the workspace config, and starts a new workspace-wide install — which includes hipthrusts again.

`prepublishOnly` only runs before `npm publish` / `npm pack`, so the build still happens for releases but not during consumer installs.

The one caveat: this only fully works once you npm publish a new version. Until then, installing from a GitHub tarball still won't have lib/