### PR TITLE
Dogfooding feedback round: fix composition/type bugs, structured errors, strict slice sanitization, adapter options (0.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_The entries below fold the previously-unreleased modernization work and the
+dogfooding-feedback fixes into the upcoming 0.12.0 release._
+
+### Added (dogfooding feedback round)
+
+- Structured error bodies: HTTP adapters now respond with
+  `{ error, issues?, detail? }`. A `ZodError` detail is projected to
+  `issues: [{ path, message }]` (paths + messages only — never received input
+  values); other `detail` is serialized only when the error was constructed
+  with the new `{ expose: true }` opt-in (`HipErrorOptions`); `HipInternal`
+  exposes nothing beyond its message. Express merges the same projection into
+  the Boom payload. (`hipErrorToBody` in `hipthrusts/errors`.)
+- `onError(error, { raw })` adapter option (all HTTP adapters): observability
+  hook called with every error the adapter converts to an error response.
+  Unknown failures carry the original error as `Error.cause`.
+- `afterResponse(context)` adapter option (all HTTP adapters): post-response
+  side effects now receive the final lifecycle context (inputs, ambient,
+  loaded resources, response).
+- `redactResponse(unsafe, context?)`: redactors may take the final context as
+  a second argument (e.g. role-dependent field redaction); a two-parameter
+  redactor's context keys participate in the deps-met type checking.
+- `HTPipe` typed overloads extended from 4 to 8 fragments.
+- `HTPipe` passes non-stage keys (e.g. `responseMeta`) through composition
+  with right-wins semantics instead of silently dropping them.
+- `SanitizeInputsSlicesWithZod({ params: P, body: B })`: validate several
+  input slices in one fragment with every slice key named in the return type.
+- Tenant-scoping helpers in `htMongooseFactory`: `findScoped(Model,
+  extraFilter?)` and `loadScopedTo(Model, key, extraFilter?)` compose
+  `ctx.queryScope` into the query and type-REQUIRE it, making a missing
+  tenant filter a compile error.
+- Readable deps-met diagnostics: an unmet context dependency now surfaces as
+  `HipDepNotMet<'stage', 'key'>` in the compiler error instead of collapsing
+  to `never`; `any`-typed context keys and union stage returns are tolerated.
+- Type-level test suite (`vitest --typecheck`, `test/*.test-d.ts`).
+
+### Changed (dogfooding feedback round)
+
+- **BREAKING:** unknown (non-`HipError`) exceptions from `preAuthorize`,
+  `loadResources`, and `finalAuthorize` now become `HipInternal` (500) with
+  the original error chained as `Error.cause` — previously they surfaced as
+  403/404/403 respectively, so infra failures masqueraded as authorization
+  or not-found results. 404 remains the deliberate signal: throw
+  `HipNotFound` (e.g. via `findByIdRequired`). Input stages keep mapping
+  unknown throws to `HipBadInputs` (422), now also with `cause`.
+- **BREAKING:** the unexpected-failure scrub message is now uniformly
+  `"Internal server error"` (exported as `INTERNAL_ERROR_MESSAGE`); core
+  previously used `"Uncaught exception"`.
+- **BREAKING:** `afterResponse` (Next adapter) now fires only after a
+  successful lifecycle (previously it was scheduled before the lifecycle and
+  fired even for failed requests) and receives the final context.
+- **BREAKING:** the Next.js and Hono adapters respond
+  `422 { "error": "Malformed JSON body" }` to non-empty bodies that fail to
+  parse as JSON instead of silently coercing them to `{}`; opt out with
+  `allowMalformedBody: true`. Empty bodies still coerce to `{}`.
+- `PipedSanitizeInputs` merges the left fragment's named keys through
+  passthrough-style right fragments, so piping two `WithInputSlice`
+  fragments keeps both slices visible to later stages (the README's own
+  multi-slice example now typechecks).
+
 ### Added
 
 - Hono, Fastify, and Next.js (App Router) adapters alongside the existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ dogfooding-feedback fixes into the upcoming 0.12.0 release._
   `issues: [{ path, message }]` (paths + messages only — never received input
   values); other `detail` is serialized only when the error was constructed
   with the new `{ expose: true }` opt-in (`HipErrorOptions`); `HipInternal`
-  exposes nothing beyond its message. Express merges the same projection into
-  the Boom payload. (`hipErrorToBody` in `hipthrusts/errors`.)
+  exposes nothing beyond its message. (`hipErrorToBody` in
+  `hipthrusts/errors`.)
 - `onError(error, { raw })` adapter option (all HTTP adapters): observability
   hook called with every error the adapter converts to an error response.
   Unknown failures carry the original error as `Error.cause`.
@@ -42,6 +42,15 @@ dogfooding-feedback fixes into the upcoming 0.12.0 release._
   `HipDepNotMet<'stage', 'key'>` in the compiler error instead of collapsing
   to `never`; `any`-typed context keys and union stage returns are tolerated.
 - Type-level test suite (`vitest --typecheck`, `test/*.test-d.ts`).
+
+### Removed (dogfooding feedback round)
+
+- **BREAKING:** the express adapter no longer depends on `@hapi/boom`. It now
+  responds to errors directly (status + `{ error, issues?, detail? }`) like
+  the other HTTP adapters. Apps with their own express error middleware can
+  pass `{ delegateErrors: true }` to `toExpressHandler` to receive the raw
+  `HipError` via `next()` and translate it with `hipErrorToStatus` /
+  `hipErrorToBody`.
 
 ### Changed (dogfooding feedback round)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@ dogfooding-feedback fixes into the upcoming 0.12.0 release._
 - `HTPipe` typed overloads extended from 4 to 8 fragments.
 - `HTPipe` passes non-stage keys (e.g. `responseMeta`) through composition
   with right-wins semantics instead of silently dropping them.
-- `SanitizeInputsSlicesWithZod({ params: P, body: B })`: validate several
-  input slices in one fragment with every slice key named in the return type.
+- `SanitizeInputsSlices({ params: fn, ... })` core helper plus
+  `SanitizeInputsSlicesWithZod` / `SanitizeInputsSlicesWithMongoose`:
+  per-slice sanitization with every slice key named in the return type.
 - Tenant-scoping helpers in `htMongooseFactory`: `findScoped(Model,
   extraFilter?)` and `loadScopedTo(Model, key, extraFilter?)` compose
   `ctx.queryScope` into the query and type-REQUIRE it, making a missing
@@ -44,6 +45,15 @@ dogfooding-feedback fixes into the upcoming 0.12.0 release._
 - Type-level test suite (`vitest --typecheck`, `test/*.test-d.ts`).
 
 ### Removed (dogfooding feedback round)
+
+- **BREAKING:** `WithInputSlice`, `SanitizeInputsSliceWithZod`, and
+  `SanitizeInputsSliceWithMongoose` are gone — replaced by the map-based
+  plural forms (`SanitizeInputsSlices({ params: fn })`,
+  `SanitizeInputsSlicesWithZod({ params: Schema })`,
+  `SanitizeInputsSlicesWithMongoose({ params: Factory })`), which handle the
+  single-slice case with the same call shape and remove the
+  one-letter-apart Slice/Slices API trap. `SanitizeInputsSlicesWithZod` no
+  longer takes a `partial` option — pass `Schema.partial()` yourself.
 
 - **BREAKING:** the express adapter no longer depends on `@hapi/boom`. It now
   responds to errors directly (status + `{ error, issues?, detail? }`) like
@@ -71,8 +81,20 @@ dogfooding-feedback fixes into the upcoming 0.12.0 release._
   `422 { "error": "Malformed JSON body" }` to non-empty bodies that fail to
   parse as JSON instead of silently coercing them to `{}`; opt out with
   `allowMalformedBody: true`. Empty bodies still coerce to `{}`.
+- **BREAKING (strictness guarantee):** only explicitly-sanitized input
+  slices survive the sanitize stage. Chained slice sanitizers pass the raw
+  remainder to each other under the exported `UNSAFE_SLICES` symbol, and
+  core deletes that channel after the stage — an unsanitized slice never
+  reaches later stages, at runtime or in the types (consuming one downstream
+  is now a compile error). Pass a raw slice through explicitly with a no-op:
+  `SanitizeInputsSlices({ query: (q) => q })`. Whole-object sanitizers
+  (tRPC-style) are unaffected.
+- **BREAKING:** `findScoped` is now a two-stage fragment: the scoped
+  `Model.find` runs on the LOAD stage (rows in context for finalAuthorize /
+  redactResponse / downstream execute stages, under `scopedDocs` or a custom
+  third-argument key) with a trivial execute returning them.
 - `PipedSanitizeInputs` merges the left fragment's named keys through
-  passthrough-style right fragments, so piping two `WithInputSlice`
+  slice-style right fragments, so piping two `SanitizeInputsSlices`
   fragments keeps both slices visible to later stages (the README's own
   multi-slice example now typechecks).
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ HipThrusTS makes the stages **the unit of work**:
 ```sh
 pnpm add hipthrusts
 # peer-installs depending on what you'll use:
-pnpm add express @hapi/boom   # Express adapter
+pnpm add express              # Express adapter
 pnpm add hono                 # Hono adapter
 pnpm add fastify              # Fastify adapter
 pnpm add next                 # Next.js (App Router) adapter
@@ -271,12 +271,15 @@ from any stage and the adapter takes care of the HTTP details:
 | `HipInternal()`      | 500                   | Unexpected failure (default for anything else).  |
 | `new HipRedirect(u)` | 302 (or what you set) | Control-flow signal; HTTP-style adapters honor.  |
 
-Adapters translate per their framework: the **Express** adapter maps to
-**Boom** so your existing error middleware keeps working unchanged. The
-**Hono / Fastify / Next.js** adapters respond directly with the mapped
-status and a JSON body. The **tRPC** adapter lets `HipError` propagate
-with its `.kind`; map it in your `errorFormatter` if you want specific
-`TRPCError` codes.
+Every HTTP adapter (**Express / Hono / Fastify / Next.js**) responds
+directly with the mapped status and a JSON body. If you'd rather have
+your own express error middleware handle errors, pass
+`{ delegateErrors: true }` to `toExpressHandler` — every error (the
+`HipError` itself, or the raw unknown exception) is forwarded to
+`next()`, and `hipErrorToStatus` / `hipErrorToBody` from
+`hipthrusts/errors` do the translation in your middleware. The **tRPC**
+adapter lets `HipError` propagate with its `.kind`; map it in your
+`errorFormatter` if you want specific `TRPCError` codes.
 
 ### What the error body contains
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ The package ships both ESM and CommonJS builds — `import` and `require`
 both work, for the root and for every subpath (`hipthrusts/express`,
 `hipthrusts/zod`, …). Node.js >= 20.
 
+Subpath types are resolved through the package `exports` map, so your
+`tsconfig.json` needs `"moduleResolution": "node16"`, `"nodenext"`, or
+`"bundler"`. The legacy `"node"` (node10) resolution cannot see the
+subpath type declarations.
+
 ## The lifecycle, in detail
 
 Every handler config is a plain object. Five methods are required; three
@@ -117,7 +122,7 @@ returned.
 | `loadResources`   | no   | async  | everything so far              | fetch the resource the request is about                    |
 | `finalAuthorize`  | yes  | async  | everything so far              | ownership/permission check with the resource in hand       |
 | `execute`         | yes  | async  | everything so far              | the actual work (mutate, compute, save)                    |
-| `redactResponse`  | yes  | sync   | unsafe response                | strip secrets/internal fields before sending               |
+| `redactResponse`  | yes  | sync   | unsafe response, final context | strip secrets/internal fields before sending               |
 
 `extractAmbient`'s output lives at `ctx.ambient`. `sanitizeInputs`'s output
 lives at `ctx.inputs`. Outputs from `preAuthorize` / `loadResources` /
@@ -136,6 +141,17 @@ finalAuthorize: (ctx) =>
 ```
 
 …and `execute` will see `ctx.isOwner` with full type information.
+
+`redactResponse` optionally takes the final context as a second
+argument, so redaction can depend on the caller — no need to smuggle
+authorization flags through the `execute` return value:
+
+```ts
+finalAuthorize: (ctx) => ({ canSeeEmails: ctx.ambient.user.role === 'admin' }),
+execute:        (ctx) => ({ rows: ctx.rows }),
+redactResponse: (unsafe, ctx: { canSeeEmails: boolean }) =>
+  ctx.canSeeEmails ? unsafe.rows : unsafe.rows.map(({ email, ...rest }) => rest),
+```
 
 ## Compose, don't repeat yourself
 
@@ -258,12 +274,44 @@ from any stage and the adapter takes care of the HTTP details:
 Adapters translate per their framework: the **Express** adapter maps to
 **Boom** so your existing error middleware keeps working unchanged. The
 **Hono / Fastify / Next.js** adapters respond directly with the mapped
-status and `{ error: message }`. The **tRPC** adapter lets `HipError`
-propagate with its `.kind`; map it in your `errorFormatter` if you want
-specific `TRPCError` codes.
+status and a JSON body. The **tRPC** adapter lets `HipError` propagate
+with its `.kind`; map it in your `errorFormatter` if you want specific
+`TRPCError` codes.
 
-Anything thrown that *isn't* a `HipError` becomes a `500` with the
-message scrubbed.
+### What the error body contains
+
+The HTTP error body is `{ error, issues?, detail? }`:
+
+- `error` — the message, always.
+- `issues` — when the error's `detail` is a `ZodError` (as thrown by the
+  zod helpers), it is projected to `[{ path, message }]` so forms can
+  render per-field errors. Paths and messages only — received input
+  values never reach the wire.
+- `detail` — arbitrary structured payload, included **only** when the
+  error was constructed with the explicit opt-in:
+
+  ```ts
+  throw new HipConflict('blocked by open items', { blockedBy }, { expose: true });
+  // -> 409 { "error": "blocked by open items", "detail": { "blockedBy": [...] } }
+  ```
+
+`HipInternal` never exposes `issues` or `detail`, opt-in or not.
+
+### Unexpected errors
+
+Anything thrown that *isn't* a `HipError` is scrubbed and routed by
+stage: the input stages (`extractAmbient` / `extractInputs` /
+`sanitizeInputs`) map unknown throws to `422` (they exist to reject bad
+input — a raw `schema.parse()` works fine there), and every later stage
+maps them to a `500` with the body `{ "error": "Internal server error" }`.
+The original error is chained as `Error.cause` on the `HipError`, so the
+adapters' `onError` hook (below) can log the real failure.
+
+> **403 vs 404:** `finalAuthorize` returning `false` is always a `403`.
+> If "the resource doesn't exist" should read as `404`, throw
+> `HipNotFound` from `loadResources` (the mongoose helper
+> `findByIdRequired` does exactly this). A `loadResources` that merely
+> returns nothing is NOT a 404 by itself.
 
 ## HTTP response metadata
 
@@ -288,6 +336,103 @@ toExpressHandler({
 `responseMeta` can be a static object (`{ status: 201 }`) or a function
 of the final context. tRPC has no `responseMeta` — procedures return
 values, not HTTP responses.
+
+`responseMeta` (like any non-stage key) passes through `HTPipe`
+composition with right-wins semantics, so it can live on any fragment.
+
+## Adapter options
+
+Every HTTP adapter (`toExpressHandler`, `toHonoHandler`,
+`toFastifyHandler`, `toNextHandler`) takes an options object as its
+second argument:
+
+```ts
+toNextHandler(handler, {
+  // Called with every error the adapter converts to an error response
+  // (redirects excluded). For unexpected failures, error.cause carries
+  // the original underlying error. A throwing hook never affects the
+  // response.
+  onError: (error, { raw }) => logger.error({ err: error }),
+
+  // Post-response side effects with the FINAL lifecycle context —
+  // inputs, ambient, loaded resources, and the response. Fires only
+  // after a successful lifecycle; never blocks or breaks the response.
+  afterResponse: async (ctx) => auditLog.write({ input: ctx.inputs, out: ctx.response }),
+});
+```
+
+The Next.js and Hono adapters (which parse JSON bodies themselves)
+additionally reject non-empty bodies that fail to parse with a
+`422 { "error": "Malformed JSON body" }` — pass
+`allowMalformedBody: true` to coerce them to `{}` instead. Empty bodies
+always coerce to `{}`. (Express and Fastify body parsing is configured
+in the framework.)
+
+The Next.js adapter also keeps its `gatherContext` option for merging
+async request context (e.g. the auth principal) into the raw envelope.
+
+## List endpoints & tenant scoping
+
+A list endpoint has no single resource to authorize, so `finalAuthorize:
+() => true` is correct — but then the tenant filter must live in the
+query itself, and forgetting it is a cross-tenant data leak. Make the
+scope a *typed context dependency* instead of a convention: one fragment
+contributes `queryScope`, and the scoped finders require it.
+
+```ts
+import { htMongooseFactory } from 'hipthrusts/mongoose';
+const { findScoped } = htMongooseFactory(mongoose);
+
+const WithTenantScope = LoadResources((ctx: { ambient: { user: User } }) => ({
+  queryScope: { businessGroup: { $in: ctx.ambient.user.accessibleGroupIds } },
+}));
+
+app.get('/things', toExpressHandler(HTPipe(
+  WithUserFromReq,
+  WithTenantScope,
+  {
+    sanitizeInputs: (i) => i,
+    preAuthorize:   (ctx) => !!ctx.ambient.user,
+    finalAuthorize: () => true,
+    ...findScoped(ThingModel),          // Model.find({ ...ctx.queryScope })
+    redactResponse: (rows) => rows.map(({ id, name }) => ({ id, name })),
+  },
+)));
+```
+
+`findScoped(Model, extraFilter?)` is an `Execute` fragment whose context
+type **requires** `queryScope` — drop `WithTenantScope` from the pipe
+and the handler no longer compiles. `loadScopedTo(Model, key,
+extraFilter?)` is the `LoadResources` variant for handlers that
+post-process the scoped rows in their own `execute`.
+
+## Type troubleshooting
+
+The deps-met machinery rejects a handler whose stages declare context
+keys nothing contributes. When that happens the compiler error names the
+stage and key via a branded type:
+
+```
+... is not assignable to ... HipDepNotMet<"finalAuthorize", "doc">
+```
+
+That means: `finalAuthorize` declares `ctx.doc`, and no earlier stage
+(`preAuthorize` / `loadResources`) returns an object with a compatible
+`doc`. Fix the provider (or the declared type), don't `as any` the
+handler.
+
+A few patterns to know:
+
+- **Keep ORM documents narrow.** Don't let a full
+  `mongoose.Document<...>` generic flow into a declared stage context —
+  declare the small structural interface you actually use
+  (`{ ownerId: string; save(): Promise<unknown> }`). It compiles faster
+  and produces readable errors.
+- **Conditional loads are fine.** `if (!doc) return {}; return { doc }`
+  (a union return) counts as providing `doc`. If the consuming stage
+  must handle the missing case, declare it optional/nullable there.
+- **`any`-typed context keys are tolerated,** but you lose the
+  guarantee that anything provides them — prefer real types.
 
 ## Validation helpers
 
@@ -322,8 +467,21 @@ app.put('/things/:id', toExpressHandler(HTPipe(
 ```
 
 A Zod parse failure throws `HipBadInputs` carrying the `ZodError` as
-`.detail` (so the issues are at `.detail.issues`); the adapter turns
-that into a 422.
+`.detail`; the adapter turns that into a
+`422 { error, issues: [{ path, message }] }` response (see
+[Errors](#errors)).
+
+To validate several slices in one fragment, use
+`SanitizeInputsSlicesWithZod` — the return type names every slice key:
+
+```ts
+const { SanitizeInputsSlicesWithZod } = htZodFactory();
+
+HTPipe(
+  SanitizeInputsSlicesWithZod({ params: Params, body: Body }),
+  { /* ...stages consuming ctx.inputs.params and ctx.inputs.body... */ },
+);
+```
 
 ### Mongoose
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,30 @@ redactResponse: (unsafe, ctx: { canSeeEmails: boolean }) =>
   ctx.canSeeEmails ? unsafe.rows : unsafe.rows.map(({ email, ...rest }) => rest),
 ```
 
+### Input slices & the strictness guarantee
+
+`sanitizeInputs` is single-slot: one function, unsafe in, safe out —
+which is exactly right for tRPC's single `input`. HTTP-style adapters
+feed it the canonical `{ params, query, body, headers }` object, and
+`SanitizeInputsSlices` gives you per-slice ergonomics on top:
+
+```ts
+SanitizeInputsSlices({
+  params: (p) => ParamsSchema.parse(p),
+  body:   (b) => BodySchema.parse(b),
+})
+```
+
+**Only slices you explicitly sanitize survive the stage.** Chained
+sanitize fragments hand the raw remainder to each other under the
+`UNSAFE_SLICES` symbol, and core deletes that channel once the stage
+completes — so an unsanitized `query` never reaches `preAuthorize` or
+anything after it, at runtime *or* in the types (consuming it downstream
+is a compile error). Want a raw slice through? Say so explicitly:
+`{ query: (q) => q }`. A plain whole-object sanitizer
+(`sanitizeInputs: (i) => …`) is likewise an explicit mapping — whatever
+it returns is, by definition, sanitized.
+
 ## Compose, don't repeat yourself
 
 The real payoff shows up the second time you need "load a Thing by ID,
@@ -182,13 +206,15 @@ export const RequireThingOwner = HTPipe(
 Then use it in every handler that needs it:
 
 ```ts
-import { HTPipe, WithInputSlice } from 'hipthrusts';
+import { HTPipe, SanitizeInputsSlices } from 'hipthrusts';
 import { toExpressHandler } from 'hipthrusts/express';
 
 app.put('/things/:id', toExpressHandler(HTPipe(
   WithUserFromReq,                                       // ambient.user
-  WithInputSlice('params', (p: any) => ({ id: String(p.id) })),
-  WithInputSlice('body',   (b: any) => ({ name: String(b.name) })),
+  SanitizeInputsSlices({
+    params: (p: any) => ({ id: String(p.id) }),
+    body:   (b: any) => ({ name: String(b.name) }),
+  }),
   RequireThingOwner,                                     // shared fragment
   {
     preAuthorize:   (ctx) => ctx.ambient.user?.role === 'editor',
@@ -210,7 +236,7 @@ and intersecting types so an `execute` written here knows it can reach
 The same shared fragments power every endpoint in a router:
 
 ```ts
-import { HTPipe, WithInputSlice } from 'hipthrusts';
+import { HTPipe, SanitizeInputsSlices } from 'hipthrusts';
 import { toExpressHandler } from 'hipthrusts/express';
 import { WithUserFromReq, RequireThingOwner } from './shared';
 
@@ -226,7 +252,7 @@ thingRouter.get('/', toExpressHandler({
 // GET /things/:id — owner-only read
 thingRouter.get('/:id', toExpressHandler(HTPipe(
   WithUserFromReq,
-  WithInputSlice('params', (p: any) => ({ id: String(p.id) })),
+  SanitizeInputsSlices({ params: (p: any) => ({ id: String(p.id) }) }),
   RequireThingOwner,
   {
     preAuthorize:   () => true,
@@ -238,8 +264,10 @@ thingRouter.get('/:id', toExpressHandler(HTPipe(
 // PUT /things/:id — owner-only update
 thingRouter.put('/:id', toExpressHandler(HTPipe(
   WithUserFromReq,
-  WithInputSlice('params', (p: any) => ({ id: String(p.id) })),
-  WithInputSlice('body',   (b: any) => ({ name: String(b.name) })),
+  SanitizeInputsSlices({
+    params: (p: any) => ({ id: String(p.id) }),
+    body:   (b: any) => ({ name: String(b.name) }),
+  }),
   RequireThingOwner,
   {
     preAuthorize:   (ctx) => ctx.ambient.user?.role === 'editor',
@@ -403,10 +431,14 @@ app.get('/things', toExpressHandler(HTPipe(
 )));
 ```
 
-`findScoped(Model, extraFilter?)` is an `Execute` fragment whose context
-type **requires** `queryScope` — drop `WithTenantScope` from the pipe
-and the handler no longer compiles. `loadScopedTo(Model, key,
-extraFilter?)` is the `LoadResources` variant for handlers that
+`findScoped(Model, extraFilter?, docsKey?)` is a two-stage fragment: the
+scoped `Model.find` runs on the **load** stage (so the rows sit in
+context — under `scopedDocs` by default — where `finalAuthorize`, a
+two-param `redactResponse`, and any downstream `execute` you pipe can
+see them) plus a trivial `execute` that returns them. Its load stage
+**requires** `queryScope` in its context type — drop `WithTenantScope`
+from the pipe and the handler no longer compiles. `loadScopedTo(Model,
+key, extraFilter?)` is the load stage alone, for handlers that
 post-process the scoped rows in their own `execute`.
 
 ## Type troubleshooting
@@ -447,7 +479,7 @@ import { HTPipe } from 'hipthrusts';
 import { toExpressHandler } from 'hipthrusts/express';
 import { htZodFactory } from 'hipthrusts/zod';
 
-const { SanitizeInputsSliceWithZod, RedactResponseWithZod } = htZodFactory();
+const { SanitizeInputsSlicesWithZod, RedactResponseWithZod } = htZodFactory();
 
 const Params = z.object({ id: z.string().uuid() });
 const Body   = z.object({ name: z.string().min(1).max(80) });
@@ -455,8 +487,7 @@ const Resp   = z.object({ id: z.string(), name: z.string() });
 
 app.put('/things/:id', toExpressHandler(HTPipe(
   WithUserFromReq,
-  SanitizeInputsSliceWithZod('params', Params),
-  SanitizeInputsSliceWithZod('body',   Body),
+  SanitizeInputsSlicesWithZod({ params: Params, body: Body }),
   RedactResponseWithZod(Resp),
   RequireThingOwner,
   {
@@ -474,17 +505,7 @@ A Zod parse failure throws `HipBadInputs` carrying the `ZodError` as
 `422 { error, issues: [{ path, message }] }` response (see
 [Errors](#errors)).
 
-To validate several slices in one fragment, use
-`SanitizeInputsSlicesWithZod` — the return type names every slice key:
-
-```ts
-const { SanitizeInputsSlicesWithZod } = htZodFactory();
-
-HTPipe(
-  SanitizeInputsSlicesWithZod({ params: Params, body: Body }),
-  { /* ...stages consuming ctx.inputs.params and ctx.inputs.body... */ },
-);
-```
+For partial-update endpoints, pass `Body.partial()` as the slice schema.
 
 ### Mongoose
 
@@ -640,7 +661,7 @@ headers }` input shape are identical across them.
 
 ## No magic
 
-The helpers (`HTPipe`, `LoadResources`, `WithInputSlice`, the
+The helpers (`HTPipe`, `LoadResources`, `SanitizeInputsSlices`, the
 `htZodFactory` family) all just produce or compose plain objects.
 Here's the opening example written longhand, with nothing but built-in
 TypeScript:

--- a/examples/express-hello.ts
+++ b/examples/express-hello.ts
@@ -2,7 +2,12 @@
 // Then:     curl -X POST localhost:4000/greet/world
 // (In your own project, import from 'hipthrusts/...' instead of '../src/...'.)
 import express, { NextFunction, Request, Response } from 'express';
-import { HipBadInputs } from '../src/errors';
+import {
+  HipBadInputs,
+  hipErrorToBody,
+  hipErrorToStatus,
+  isHipError,
+} from '../src/errors';
 import { defineExpressHandler, toExpressHandler } from '../src/express';
 
 const greet = defineExpressHandler({
@@ -23,12 +28,15 @@ const greet = defineExpressHandler({
 
 const app = express();
 app.use(express.json());
-app.post('/greet/:name', toExpressHandler(greet));
+// By default the adapter responds to errors directly
+// (status + { error, issues?, detail? }) — no error middleware needed.
+// This example opts into `delegateErrors` to show the middleware route:
+app.post('/greet/:name', toExpressHandler(greet, { delegateErrors: true }));
 
-// Express error middleware: hipthrusts hands Boom errors to next().
-app.use((err: any, req: Request, res: Response, _next: NextFunction) => {
-  if (err && err.isBoom) {
-    res.status(err.output.statusCode).json(err.output.payload);
+// With delegateErrors, every error reaches next(); translate it yourself:
+app.use((err: unknown, req: Request, res: Response, _next: NextFunction) => {
+  if (isHipError(err)) {
+    res.status(hipErrorToStatus(err)).json(hipErrorToBody(err));
   } else {
     res.status(500).json({ error: 'Internal server error' });
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hipthrusts",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/trycatchal/hipthrusts.git"
@@ -67,7 +67,8 @@
     "check:exports": "attw --pack . --profile node16",
     "smoke": "node scripts/smoke.cjs && node scripts/smoke.mjs",
     "docs:build": "typedoc",
-    "prepublishOnly": "pnpm clean && pnpm build && pnpm check:exports && pnpm smoke"
+    "prepublishOnly": "pnpm clean && pnpm build && pnpm check:exports && pnpm smoke",
+    "prepack": "pnpm clean && pnpm build"
   },
   "license": "MIT",
   "packageManager": "pnpm@10.33.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
   "license": "MIT",
   "packageManager": "pnpm@10.33.0",
   "peerDependencies": {
-    "@hapi/boom": "^10.0.0",
     "express": "^5.1.0",
     "fastify": "^5.0.0",
     "hono": "^4.0.0",
@@ -83,9 +82,6 @@
     "zod": "^4.0.0"
   },
   "peerDependenciesMeta": {
-    "@hapi/boom": {
-      "optional": true
-    },
     "express": {
       "optional": true
     },
@@ -111,7 +107,6 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.5",
     "@eslint/js": "^10.0.1",
-    "@hapi/boom": "^10.0.1",
     "@hono/node-server": "^2.0.4",
     "@types/express": "^5.0.6",
     "@types/node": "^25.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.7.0)
-      '@hapi/boom':
-        specifier: ^10.0.1
-        version: 10.0.1
       '@hono/node-server':
         specifier: ^2.0.4
         version: 2.0.4(hono@4.12.23)
@@ -347,12 +344,6 @@ packages:
 
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
-
-  '@hapi/boom@10.0.1':
-    resolution: {integrity: sha512-ERcCZaEjdH3OgSJlyjVk8pHIFeus91CjKP3v+MpgBNp5IvGzP2l/bRiD78nqYcKPaZdbKkK5vDBVPd2ohHBlsA==}
-
-  '@hapi/hoek@11.0.7':
-    resolution: {integrity: sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==}
 
   '@hono/node-server@2.0.4':
     resolution: {integrity: sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==}
@@ -2530,12 +2521,6 @@ snapshots:
       '@shikijs/themes': 3.23.0
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
-
-  '@hapi/boom@10.0.1':
-    dependencies:
-      '@hapi/hoek': 11.0.7
-
-  '@hapi/hoek@11.0.7': {}
 
   '@hono/node-server@2.0.4(hono@4.12.23)':
     dependencies:

--- a/src/core.ts
+++ b/src/core.ts
@@ -3,7 +3,6 @@ import {
   HipError,
   HipForbidden,
   HipInternal,
-  HipNotFound,
   HipRedirect,
   isHipError,
 } from './errors.js';
@@ -124,7 +123,7 @@ export function authorizationPassed<TAuthOut extends boolean | object>(
 }
 
 function transformThrowSync<TOrigFn extends (param: any) => any>(
-  toThrow: HipError,
+  toThrow: (cause: unknown) => HipError,
   origFn: TOrigFn,
   origParam: Parameters<TOrigFn>[0]
 ): ReturnType<TOrigFn> {
@@ -134,7 +133,7 @@ function transformThrowSync<TOrigFn extends (param: any) => any>(
     if (exception instanceof HipRedirect || isHipError(exception)) {
       throw exception;
     } else {
-      throw toThrow;
+      throw toThrow(exception);
     }
   }
 }
@@ -142,7 +141,7 @@ function transformThrowSync<TOrigFn extends (param: any) => any>(
 async function transformThrowPossiblyAsync<
   TOrigFn extends (param: any) => PromiseOrSync<any>,
 >(
-  toThrow: HipError,
+  toThrow: (cause: unknown) => HipError,
   origFn: TOrigFn,
   origParam: Parameters<TOrigFn>[0]
 ): Promise<PromiseResolveOrSync<ReturnType<TOrigFn>>> {
@@ -152,10 +151,17 @@ async function transformThrowPossiblyAsync<
     if (exception instanceof HipRedirect || isHipError(exception)) {
       throw exception;
     } else {
-      throw toThrow;
+      throw toThrow(exception);
     }
   }
 }
+
+// One scrub message for every unexpected (non-HipError) failure, shared with
+// the adapters' outer catch so clients see a single vocabulary.
+export const INTERNAL_ERROR_MESSAGE = 'Internal server error';
+
+const internalFrom = (cause: unknown) =>
+  new HipInternal(INTERNAL_ERROR_MESSAGE, undefined, { cause });
 
 // Runs the full lifecycle and returns the safe response plus the final context
 // (inputs/ambient/loaded resources/auth output/execute output/response). The
@@ -170,7 +176,11 @@ export async function executeHipthrustable<
     RedactResponseDepsMet<TConf>,
   TRaw,
 >(requestHandler: TConf, raw: TRaw) {
-  const badDataThrow = new HipBadInputs('User input sanitization failure');
+  // Unknown throws during input handling stay 422: these stages exist to
+  // reject untrusted input, and validators (zod .parse etc.) throw their own
+  // library errors. The original error is chained as `cause` for logging.
+  const badDataThrow = (cause: unknown) =>
+    new HipBadInputs('User input sanitization failure', undefined, { cause });
 
   const safeAmbient = transformThrowSync(
     badDataThrow,
@@ -201,8 +211,11 @@ export async function executeHipthrustable<
     'General pre-authorization lacking for this resource'
   );
 
+  // Denial (returning/throwing an authorization outcome) is 403; an UNKNOWN
+  // throw here is an app bug or infra failure, not a denial — route it to 500
+  // so outages don't masquerade as authorization results.
   const preAuthorizeResult = transformThrowSync(
-    forbiddenPreAuthThrow,
+    internalFrom,
     requestHandler.preAuthorize,
     inputsContext
   );
@@ -221,10 +234,13 @@ export async function executeHipthrustable<
     ...preAuthorizeContextOut,
   };
 
-  const notFoundThrow = new HipNotFound('Resource not found');
+  // 404 is a DELIBERATE signal: throw HipNotFound (e.g. via findByIdRequired)
+  // when a required resource is missing. An unknown throw here — a dropped DB
+  // connection, a bug — becomes a 500 with the original error chained as
+  // `cause`, so infra failures no longer masquerade as "not found".
   const attachedDataContextOnly =
     (await transformThrowPossiblyAsync(
-      notFoundThrow,
+      internalFrom,
       requestHandler.loadResources,
       preAuthContext
     )) || {};
@@ -235,7 +251,7 @@ export async function executeHipthrustable<
   );
 
   const finalAuthorizeResult = await transformThrowPossiblyAsync(
-    forbiddenFinalAuthThrow,
+    internalFrom,
     requestHandler.finalAuthorize,
     attachedDataContext
   );
@@ -277,7 +293,7 @@ export async function executeHipthrustable<
     if (exception instanceof HipRedirect || isHipError(exception)) {
       throw exception;
     } else {
-      throw new HipInternal('Uncaught exception');
+      throw internalFrom(exception);
     }
   }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -277,7 +277,10 @@ export async function executeHipthrustable<
       requestHandler.execute(finalAuthContext)
     );
 
-    const safeResponse = requestHandler.redactResponse(unsafeResponse);
+    const safeResponse = requestHandler.redactResponse(
+      unsafeResponse,
+      finalAuthContext
+    );
 
     const context =
       unsafeResponse !== null && typeof unsafeResponse === 'object'

--- a/src/core.ts
+++ b/src/core.ts
@@ -33,6 +33,7 @@ import {
   PromiseOrSync,
   PromiseResolveOrSync,
   RedactResponseDepsMet,
+  UNSAFE_SLICES,
 } from './types.js';
 
 export function withDefaultImplementations<
@@ -196,11 +197,24 @@ export async function executeHipthrustable<
     { ...(raw as any), ...ambientSlot }
   );
 
-  const safeInputs = transformThrowSync(
+  const sanitizeOutput = transformThrowSync(
     badDataThrow,
     requestHandler.sanitizeInputs,
     unsafeInputs
   );
+
+  // The strictness guarantee: slice-style sanitizers pass the raw remainder
+  // to each other under UNSAFE_SLICES, and it dies HERE — nothing reaches
+  // later stages except what a sanitizer explicitly returned.
+  let safeInputs = sanitizeOutput;
+  if (
+    safeInputs !== null &&
+    typeof safeInputs === 'object' &&
+    UNSAFE_SLICES in safeInputs
+  ) {
+    safeInputs = { ...(safeInputs as object) };
+    delete (safeInputs as Record<PropertyKey, unknown>)[UNSAFE_SLICES];
+  }
 
   const inputsContext = {
     ambient: safeAmbient,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,8 +1,8 @@
 // Transport-agnostic error hierarchy.
 //
 // The core lifecycle throws these semantic errors; each adapter translates
-// them to its framework-native shape (Boom for express, TRPCError for tRPC,
-// etc.). This keeps HTTP/library specifics out of core.
+// them to its transport's shape (an HTTP status + JSON body, or propagation
+// for tRPC). This keeps HTTP/library specifics out of core.
 
 export type HipErrorKind =
   | 'badInputs'
@@ -76,9 +76,9 @@ export function isHipError(thing: unknown): thing is HipError {
   return thing instanceof HipError;
 }
 
-// Maps a transport-agnostic HipError to an HTTP status code. Used by adapters
-// that respond with a raw status + JSON body (Hono, Fastify, Next.js). The
-// express adapter maps to Boom instead and does not use this.
+// Maps a transport-agnostic HipError to an HTTP status code. Used by every
+// adapter that responds with a raw status + JSON body (Express, Hono,
+// Fastify, Next.js).
 export function hipErrorToStatus(error: HipError): number {
   switch (error.kind) {
     case 'badInputs':

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -96,6 +96,55 @@ export function hipErrorToStatus(error: HipError): number {
   }
 }
 
+// Wire shape for HipError responses across the HTTP adapters.
+export interface HipErrorBody {
+  error: string;
+  // Present when `detail` is a ZodError(-like): paths + messages ONLY, never
+  // the received input values (those can contain secrets).
+  issues?: { path: (string | number)[]; message: string }[];
+  // Present only when the error was constructed with `{ expose: true }`.
+  detail?: unknown;
+}
+
+// Duck-typed so this works with any zod version (and zod-compatible
+// validators) without importing zod into core.
+function isZodErrorLike(
+  detail: unknown
+): detail is { issues: { path?: unknown; message?: unknown }[] } {
+  return (
+    typeof detail === 'object' &&
+    detail !== null &&
+    Array.isArray((detail as { issues?: unknown }).issues)
+  );
+}
+
+// Projects a HipError to the JSON body adapters put on the wire. `detail` is
+// NEVER dumped verbatim: a ZodError is reduced to paths + messages, anything
+// else requires the explicit `{ expose: true }` opt-in at construction time,
+// and HipInternal exposes nothing beyond its message.
+export function hipErrorToBody(error: HipError): HipErrorBody {
+  const body: HipErrorBody = { error: error.message };
+  if (error.kind === 'internal' || error.detail === undefined) {
+    return body;
+  }
+  if (isZodErrorLike(error.detail)) {
+    body.issues = error.detail.issues.map((issue) => ({
+      path: Array.isArray(issue.path)
+        ? issue.path.filter(
+            (segment): segment is string | number =>
+              typeof segment === 'string' || typeof segment === 'number'
+          )
+        : [],
+      message: typeof issue.message === 'string' ? issue.message : '',
+    }));
+    return body;
+  }
+  if (error.exposeDetail) {
+    body.detail = error.detail;
+  }
+  return body;
+}
+
 // Control-flow signal, not an error: instructs HTTP-style adapters to issue a
 // redirect. Non-HTTP adapters treat it as an internal error.
 export class HipRedirect {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -12,13 +12,29 @@ export type HipErrorKind =
   | 'conflict'
   | 'internal';
 
+export interface HipErrorOptions {
+  // Chains the underlying failure for logging/debugging (standard Error.cause).
+  // Never serialized to clients.
+  cause?: unknown;
+  // Opt-in to serializing `detail` in HTTP error bodies (see hipErrorToBody).
+  // Off by default so unexpected internals stay scrubbed; set it when app code
+  // deliberately throws a structured payload the client should render.
+  expose?: boolean;
+}
+
 export abstract class HipError extends Error {
   public abstract readonly kind: HipErrorKind;
+  public readonly exposeDetail: boolean;
   constructor(
     message?: string,
-    public readonly detail?: unknown
+    public readonly detail?: unknown,
+    options?: HipErrorOptions
   ) {
-    super(message);
+    super(
+      message,
+      options?.cause !== undefined ? { cause: options.cause } : undefined
+    );
+    this.exposeDetail = options?.expose === true;
     // Maintain a correct prototype chain when extending a built-in under
     // ES5-targeted transpilation, and give each subclass a useful `name`.
     Object.setPrototypeOf(this, new.target.prototype);

--- a/src/express.ts
+++ b/src/express.ts
@@ -123,7 +123,17 @@ type ExpressHandlerConfig<
       PromiseResolveOrSync<TLoadResourcesOut> &
       PromiseResolveOrSync<TFinalAuthOut>
   ) => PromiseOrSync<TUnsafeResponse>;
-  redactResponse: (unsafe: PromiseResolveOrSync<TUnsafeResponse>) => TResponse;
+  redactResponse: (
+    unsafe: PromiseResolveOrSync<TUnsafeResponse>,
+    context: { inputs: PromiseResolveOrSync<TSafeInputs> } & ([
+      TAmbient,
+    ] extends [never]
+      ? {}
+      : { ambient: TAmbient }) &
+      PromiseResolveOrSync<TPreAuthOut> &
+      PromiseResolveOrSync<TLoadResourcesOut> &
+      PromiseResolveOrSync<TFinalAuthOut>
+  ) => TResponse;
   responseMeta?: ResponseMeta | ((ctx: any) => ResponseMeta);
 };
 

--- a/src/express.ts
+++ b/src/express.ts
@@ -5,7 +5,7 @@ import {
   executeHipthrustable,
   withDefaultImplementations,
 } from './core.js';
-import { HipError, HipRedirect, isHipError } from './errors.js';
+import { hipErrorToBody, HipError, HipRedirect, isHipError } from './errors.js';
 import { HasResponseMeta, ResponseMeta } from './http-adapter.js';
 import {
   ExecuteDepsMet,
@@ -33,22 +33,38 @@ export interface ExpressRaw {
 }
 
 // Maps a transport-agnostic HipError to its Boom equivalent so existing express
-// error-handling middleware keeps working unchanged.
+// error-handling middleware keeps working unchanged. The safe hipErrorToBody
+// projection (zod issues / opted-in detail) is merged into the Boom payload so
+// it reaches the wire like it does with the other HTTP adapters.
 function hipErrorToBoom(error: HipError): Error {
+  let boom: Boom.Boom;
   switch (error.kind) {
     case 'badInputs':
-      return Boom.badData(error.message, error.detail);
+      boom = Boom.badData(error.message, error.detail);
+      break;
     case 'unauthorized':
-      return Boom.unauthorized(error.message);
+      boom = Boom.unauthorized(error.message);
+      break;
     case 'forbidden':
-      return Boom.forbidden(error.message);
+      boom = Boom.forbidden(error.message);
+      break;
     case 'notFound':
-      return Boom.notFound(error.message);
+      boom = Boom.notFound(error.message);
+      break;
     case 'conflict':
-      return Boom.conflict(error.message);
+      boom = Boom.conflict(error.message);
+      break;
     default:
-      return Boom.badImplementation(error.message);
+      boom = Boom.badImplementation(error.message);
   }
+  const body = hipErrorToBody(error);
+  if (body.issues !== undefined) {
+    (boom.output.payload as Record<string, unknown>).issues = body.issues;
+  }
+  if (body.detail !== undefined) {
+    (boom.output.payload as Record<string, unknown>).detail = body.detail;
+  }
+  return boom;
 }
 
 // Handler config the dev writes for an express endpoint.

--- a/src/express.ts
+++ b/src/express.ts
@@ -1,11 +1,15 @@
-import Boom from '@hapi/boom';
 import { NextFunction, Request, Response } from 'express';
 import {
   assertHipthrustable,
   executeHipthrustable,
   withDefaultImplementations,
 } from './core.js';
-import { hipErrorToBody, HipError, HipRedirect, isHipError } from './errors.js';
+import {
+  hipErrorToBody,
+  hipErrorToStatus,
+  HipRedirect,
+  isHipError,
+} from './errors.js';
 import {
   HasResponseMeta,
   HttpAdapterOptions,
@@ -38,39 +42,13 @@ export interface ExpressRaw {
   res: Response;
 }
 
-// Maps a transport-agnostic HipError to its Boom equivalent so existing express
-// error-handling middleware keeps working unchanged. The safe hipErrorToBody
-// projection (zod issues / opted-in detail) is merged into the Boom payload so
-// it reaches the wire like it does with the other HTTP adapters.
-function hipErrorToBoom(error: HipError): Error {
-  let boom: Boom.Boom;
-  switch (error.kind) {
-    case 'badInputs':
-      boom = Boom.badData(error.message, error.detail);
-      break;
-    case 'unauthorized':
-      boom = Boom.unauthorized(error.message);
-      break;
-    case 'forbidden':
-      boom = Boom.forbidden(error.message);
-      break;
-    case 'notFound':
-      boom = Boom.notFound(error.message);
-      break;
-    case 'conflict':
-      boom = Boom.conflict(error.message);
-      break;
-    default:
-      boom = Boom.badImplementation(error.message);
-  }
-  const body = hipErrorToBody(error);
-  if (body.issues !== undefined) {
-    (boom.output.payload as Record<string, unknown>).issues = body.issues;
-  }
-  if (body.detail !== undefined) {
-    (boom.output.payload as Record<string, unknown>).detail = body.detail;
-  }
-  return boom;
+export interface HipExpressHandlerOptions extends HttpAdapterOptions {
+  // By default the adapter responds to errors directly (status +
+  // { error, issues?, detail? }), matching the other HTTP adapters. Set true
+  // to instead forward every error — the HipError itself, or the raw unknown
+  // exception — to next() so your own express error middleware handles it
+  // (use hipErrorToStatus/hipErrorToBody from 'hipthrusts/errors' there).
+  delegateErrors?: boolean;
 }
 
 // Handler config the dev writes for an express endpoint.
@@ -183,7 +161,7 @@ export function toExpressHandler<
     ExecuteDepsMet<TConf> &
     RedactResponseDepsMet<TConf> &
     HasResponseMeta,
->(handlingStrategy: TConf, options: HttpAdapterOptions = {}) {
+>(handlingStrategy: TConf, options: HipExpressHandlerOptions = {}) {
   assertHipthrustable(handlingStrategy);
 
   // Compose: baseline runs first, handler's extractInputs (if any) chains after.
@@ -234,10 +212,12 @@ export function toExpressHandler<
       }
       if (exception instanceof HipRedirect) {
         res.redirect(exception.redirectCode, exception.redirectUrl);
-      } else if (isHipError(exception)) {
-        next(hipErrorToBoom(exception));
-      } else {
+      } else if (options.delegateErrors) {
         next(exception);
+      } else if (isHipError(exception)) {
+        res.status(hipErrorToStatus(exception)).json(hipErrorToBody(exception));
+      } else {
+        res.status(500).json({ error: 'Internal server error' });
       }
     }
   };

--- a/src/express.ts
+++ b/src/express.ts
@@ -6,7 +6,13 @@ import {
   withDefaultImplementations,
 } from './core.js';
 import { hipErrorToBody, HipError, HipRedirect, isHipError } from './errors.js';
-import { HasResponseMeta, ResponseMeta } from './http-adapter.js';
+import {
+  HasResponseMeta,
+  HttpAdapterOptions,
+  ResponseMeta,
+  safeInvokeAfterResponse,
+  safeInvokeOnError,
+} from './http-adapter.js';
 import {
   ExecuteDepsMet,
   FinalAuthorizeDepsMet,
@@ -167,7 +173,7 @@ export function toExpressHandler<
     ExecuteDepsMet<TConf> &
     RedactResponseDepsMet<TConf> &
     HasResponseMeta,
->(handlingStrategy: TConf) {
+>(handlingStrategy: TConf, options: HttpAdapterOptions = {}) {
   assertHipthrustable(handlingStrategy);
 
   // Compose: baseline runs first, handler's extractInputs (if any) chains after.
@@ -206,8 +212,16 @@ export function toExpressHandler<
           res.setHeader(headerName, meta.headers[headerName]);
         }
       }
+      if (options.afterResponse) {
+        res.on('finish', () =>
+          safeInvokeAfterResponse(options.afterResponse, context)
+        );
+      }
       res.status(meta.status || 200).json(response);
     } catch (exception) {
+      if (!(exception instanceof HipRedirect)) {
+        safeInvokeOnError(options.onError, exception, { raw: { req, res } });
+      }
       if (exception instanceof HipRedirect) {
         res.redirect(exception.redirectCode, exception.redirectUrl);
       } else if (isHipError(exception)) {

--- a/src/fastify.ts
+++ b/src/fastify.ts
@@ -9,9 +9,12 @@ import {
 import {
   composeHttpHipthrustable,
   HasResponseMeta,
+  HttpAdapterOptions,
   HttpHandlerConfig,
   HttpRawInputs,
   resolveResponseMeta,
+  safeInvokeAfterResponse,
+  safeInvokeOnError,
 } from './http-adapter.js';
 import {
   ExecuteDepsMet,
@@ -77,7 +80,7 @@ export function toFastifyHandler<
     ExecuteDepsMet<TConf> &
     RedactResponseDepsMet<TConf> &
     HasResponseMeta,
->(handlingStrategy: TConf) {
+>(handlingStrategy: TConf, options: HttpAdapterOptions = {}) {
   const fullHipthrustable = composeHttpHipthrustable<FastifyRaw>(
     handlingStrategy,
     fastifyBaselineExtractInputs
@@ -96,8 +99,17 @@ export function toFastifyHandler<
           reply.header(headerName, meta.headers[headerName]);
         }
       }
+      if (options.afterResponse) {
+        // Fastify is Node-only; schedule off the response path.
+        setImmediate(() =>
+          safeInvokeAfterResponse(options.afterResponse, context)
+        );
+      }
       return reply.status(meta.status || 200).send(response);
     } catch (exception) {
+      if (!(exception instanceof HipRedirect)) {
+        safeInvokeOnError(options.onError, exception, { raw: { req, reply } });
+      }
       if (exception instanceof HipRedirect) {
         return reply.redirect(exception.redirectUrl, exception.redirectCode);
       } else if (isHipError(exception)) {

--- a/src/fastify.ts
+++ b/src/fastify.ts
@@ -1,6 +1,11 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { executeHipthrustable } from './core.js';
-import { hipErrorToStatus, HipRedirect, isHipError } from './errors.js';
+import {
+  hipErrorToBody,
+  hipErrorToStatus,
+  HipRedirect,
+  isHipError,
+} from './errors.js';
 import {
   composeHttpHipthrustable,
   HasResponseMeta,
@@ -98,7 +103,7 @@ export function toFastifyHandler<
       } else if (isHipError(exception)) {
         return reply
           .status(hipErrorToStatus(exception))
-          .send({ error: exception.message });
+          .send(hipErrorToBody(exception));
       }
       return reply.status(500).send({ error: 'Internal server error' });
     }

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -6,12 +6,16 @@ import {
   HipRedirect,
   isHipError,
 } from './errors.js';
+import { HipBadInputs } from './errors.js';
 import {
   composeHttpHipthrustable,
   HasResponseMeta,
+  HttpAdapterOptions,
   HttpHandlerConfig,
   HttpRawInputs,
   resolveResponseMeta,
+  safeInvokeAfterResponse,
+  safeInvokeOnError,
 } from './http-adapter.js';
 import {
   ExecuteDepsMet,
@@ -28,6 +32,13 @@ import {
 // the adapter before the synchronous lifecycle runs).
 export interface HonoRaw extends HttpRawInputs {
   c: Context;
+}
+
+export interface HipHonoHandlerOptions extends HttpAdapterOptions {
+  // A non-empty request body that fails to parse as JSON responds 422 by
+  // default (previously it silently became `{}`). Set true to restore the old
+  // coerce-to-{} behavior.
+  allowMalformedBody?: boolean;
 }
 
 const BODYLESS_METHODS = ['GET', 'HEAD', 'DELETE'];
@@ -79,7 +90,7 @@ export function toHonoHandler<
     ExecuteDepsMet<TConf> &
     RedactResponseDepsMet<TConf> &
     HasResponseMeta,
->(handlingStrategy: TConf) {
+>(handlingStrategy: TConf, options: HipHonoHandlerOptions = {}) {
   const fullHipthrustable = composeHttpHipthrustable<HonoRaw>(
     handlingStrategy,
     honoBaselineExtractInputs
@@ -87,16 +98,24 @@ export function toHonoHandler<
   const responseMeta = (handlingStrategy as HasResponseMeta).responseMeta;
 
   return async (c: Context) => {
+    let raw: HonoRaw | undefined;
     try {
       let body: any = {};
       if (!BODYLESS_METHODS.includes(c.req.method)) {
-        try {
-          body = await c.req.json();
-        } catch {
-          body = {};
+        const text = await c.req.text();
+        if (text.trim() !== '') {
+          try {
+            body = JSON.parse(text);
+          } catch {
+            if (options.allowMalformedBody) {
+              body = {};
+            } else {
+              throw new HipBadInputs('Malformed JSON body');
+            }
+          }
         }
       }
-      const raw: HonoRaw = {
+      raw = {
         c,
         params: c.req.param(),
         query: c.req.query(),
@@ -107,6 +126,17 @@ export function toHonoHandler<
         fullHipthrustable as any,
         raw
       );
+      if (options.afterResponse) {
+        const runAfterResponse = () =>
+          safeInvokeAfterResponse(options.afterResponse, context);
+        try {
+          // On edge runtimes waitUntil keeps the worker alive for the side
+          // effect; on Node hono has no executionCtx, so fall back to a task.
+          c.executionCtx.waitUntil(Promise.resolve().then(runAfterResponse));
+        } catch {
+          setTimeout(runAfterResponse, 0);
+        }
+      }
       const meta = resolveResponseMeta(responseMeta, context);
       if (meta.headers) {
         for (const headerName of Object.keys(meta.headers)) {
@@ -115,6 +145,9 @@ export function toHonoHandler<
       }
       return c.json(response, (meta.status || 200) as any);
     } catch (exception) {
+      if (!(exception instanceof HipRedirect)) {
+        safeInvokeOnError(options.onError, exception, { raw });
+      }
       if (exception instanceof HipRedirect) {
         return c.redirect(exception.redirectUrl, exception.redirectCode as any);
       } else if (isHipError(exception)) {

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -1,6 +1,11 @@
 import { Context } from 'hono';
 import { executeHipthrustable } from './core.js';
-import { hipErrorToStatus, HipRedirect, isHipError } from './errors.js';
+import {
+  hipErrorToBody,
+  hipErrorToStatus,
+  HipRedirect,
+  isHipError,
+} from './errors.js';
 import {
   composeHttpHipthrustable,
   HasResponseMeta,
@@ -114,7 +119,7 @@ export function toHonoHandler<
         return c.redirect(exception.redirectUrl, exception.redirectCode as any);
       } else if (isHipError(exception)) {
         return c.json(
-          { error: exception.message },
+          hipErrorToBody(exception) as any,
           hipErrorToStatus(exception) as any
         );
       }

--- a/src/http-adapter.ts
+++ b/src/http-adapter.ts
@@ -23,6 +23,52 @@ export interface HasResponseMeta<TCtx = any> {
   responseMeta?: ResponseMeta | ((ctx: TCtx) => ResponseMeta);
 }
 
+// Options shared by every HTTP adapter.
+export interface HttpAdapterOptions {
+  // Observability seam: called with every error the adapter converts to an
+  // error response (HipErrors and unknown failures alike; redirects excluded).
+  // With unknown-error cause-chaining, `error.cause` holds the real underlying
+  // failure. A throwing onError never affects the response.
+  onError?: (error: unknown, info: { raw?: unknown }) => void;
+  // Post-response side effects (audit logs, notifications) with access to the
+  // full final lifecycle context (inputs, ambient, loaded resources, response).
+  // Runs only after a SUCCESSFUL lifecycle; failures never fire it. Errors
+  // thrown from it never affect the response.
+  afterResponse?: (context: Record<string, unknown>) => void | Promise<void>;
+}
+
+// Invokes onError so that a broken logging hook can never break the response.
+export function safeInvokeOnError(
+  onError: HttpAdapterOptions['onError'],
+  error: unknown,
+  info: { raw?: unknown }
+) {
+  if (!onError) {
+    return;
+  }
+  try {
+    onError(error, info);
+  } catch {
+    // Logging failures are intentionally swallowed.
+  }
+}
+
+// Fire-and-forget afterResponse; sync throws and async rejections are both
+// swallowed so side effects can never affect the (already sent) response.
+export function safeInvokeAfterResponse(
+  afterResponse: HttpAdapterOptions['afterResponse'],
+  context: Record<string, unknown>
+) {
+  if (!afterResponse) {
+    return;
+  }
+  try {
+    Promise.resolve(afterResponse(context)).catch(() => {});
+  } catch {
+    // Side-effect failures are intentionally swallowed.
+  }
+}
+
 // Generic HTTP handler config, parameterized by the framework raw type so each
 // adapter supplies its own shape for extractAmbient/extractInputs. Everything
 // from sanitizeInputs onward is framework-independent.

--- a/src/http-adapter.ts
+++ b/src/http-adapter.ts
@@ -120,7 +120,17 @@ export type HttpHandlerConfig<
       PromiseResolveOrSync<TLoadResourcesOut> &
       PromiseResolveOrSync<TFinalAuthOut>
   ) => PromiseOrSync<TUnsafeResponse>;
-  redactResponse: (unsafe: PromiseResolveOrSync<TUnsafeResponse>) => TResponse;
+  redactResponse: (
+    unsafe: PromiseResolveOrSync<TUnsafeResponse>,
+    context: { inputs: PromiseResolveOrSync<TSafeInputs> } & ([
+      TAmbient,
+    ] extends [never]
+      ? {}
+      : { ambient: TAmbient }) &
+      PromiseResolveOrSync<TPreAuthOut> &
+      PromiseResolveOrSync<TLoadResourcesOut> &
+      PromiseResolveOrSync<TFinalAuthOut>
+  ) => TResponse;
   responseMeta?: ResponseMeta | ((ctx: any) => ResponseMeta);
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -506,13 +506,42 @@ type PipedExtractInputs<TLeft, TRight> = [TLeft] extends [
     ? { extractInputs: TRight['extractInputs'] }
     : {};
 
+// Strips index signatures, keeping only statically-known keys. Needed because
+// slice-style sanitizers (WithInputSlice) return `{...} & Record<string, any>`,
+// and `Omit<X, keyof (Y & Record<string, any>)>` would omit EVERYTHING.
+type KnownKeys<T> = {
+  [K in keyof T as string extends K
+    ? never
+    : number extends K
+      ? never
+      : symbol extends K
+        ? never
+        : K]: T[K];
+};
+
+// Sanitize stages CHAIN (the right one consumes the left one's output), so the
+// composed return type depends on the right fragment's style:
+// - passthrough style (has an index signature, e.g. WithInputSlice): unknown
+//   keys flow through at runtime, so the left fragment's named keys survive —
+//   merge them in (right wins on clashes).
+// - full-replace style (no index signature): the right return describes the
+//   entire output; the left's keys are gone.
+type ChainedSanitizeReturn<TLeftReturn, TRightReturn> =
+  string extends keyof TRightReturn
+    ? TRightReturn &
+        Omit<KnownKeys<TLeftReturn>, keyof KnownKeys<TRightReturn>>
+    : TRightReturn;
+
 type PipedSanitizeInputs<TLeft, TRight> = [TLeft] extends [
   HasSanitizeInputs<any, any>,
 ]
   ? [TRight] extends [HasSanitizeInputs<any, any>]
     ? HasSanitizeInputs<
         SanitizeInputsContextIn<TLeft>,
-        SanitizeInputsReturn<TRight>
+        ChainedSanitizeReturn<
+          SanitizeInputsReturn<TLeft>,
+          SanitizeInputsReturn<TRight>
+        >
       >
     : { sanitizeInputs: TLeft['sanitizeInputs'] }
   : [TRight] extends [HasSanitizeInputs<any, any>]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1303,9 +1303,10 @@ export function HTPipe(...objs: any[]) {
             : {}) as PipedExecute<any, any>),
       ...((isHasRedactResponse(left) && isHasRedactResponse(right)
         ? {
-            redactResponse: (context: any) => {
-              const leftOut = left.redactResponse(context) || {};
-              const rightOut = right.redactResponse(leftOut) || {};
+            redactResponse: (unsafeResponse: any, context: any) => {
+              const leftOut =
+                left.redactResponse(unsafeResponse, context) || {};
+              const rightOut = right.redactResponse(leftOut, context) || {};
               return rightOut;
             },
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
 } from './lifecycle-functions.js';
 import {
   AllStageKeys,
+  AllStagesOptionalShape,
   HasExecute,
   HasExtractAmbient,
   HasExtractInputs,
@@ -528,8 +529,7 @@ type KnownKeys<T> = {
 //   entire output; the left's keys are gone.
 type ChainedSanitizeReturn<TLeftReturn, TRightReturn> =
   string extends keyof TRightReturn
-    ? TRightReturn &
-        Omit<KnownKeys<TLeftReturn>, keyof KnownKeys<TRightReturn>>
+    ? TRightReturn & Omit<KnownKeys<TLeftReturn>, keyof KnownKeys<TRightReturn>>
     : TRightReturn;
 
 type PipedSanitizeInputs<TLeft, TRight> = [TLeft] extends [
@@ -762,6 +762,19 @@ type NonStageKeys<T> = Omit<KnownKeys<T>, AllStageKeys>;
 type PipedPassthrough<TLeft, TRight> = NonStageKeys<TRight> &
   Omit<NonStageKeys<TLeft>, keyof NonStageKeys<TRight>>;
 
+// Flat variant for the 5+-arity overloads: folds right-wins passthrough over
+// the raw fragment tuple (first fragment = leftmost = lowest precedence).
+// Operating on plain fragments instead of nested PipedAll folds keeps the
+// mapped-type instantiation cost linear.
+type PipedPassthroughAll<Ts extends readonly any[]> = Ts extends [
+  infer THead,
+  ...infer TRest,
+]
+  ? TRest extends []
+    ? NonStageKeys<THead>
+    : PipedPassthrough<THead, PipedPassthroughAll<TRest>>
+  : {};
+
 const ALL_STAGE_KEYS: AllStageKeys[] = [
   'extractAmbient',
   'extractInputs',
@@ -772,6 +785,17 @@ const ALL_STAGE_KEYS: AllStageKeys[] = [
   'execute',
   'redactResponse',
 ];
+
+// Compact aliases for the higher arities: the intersection composes the same
+// way per-stage folds do, because each PipedX contributes a disjoint key.
+type PipedAll<TLeft, TRight> = PipedExtractAmbient<TLeft, TRight> &
+  PipedExtractInputs<TLeft, TRight> &
+  PipedSanitizeInputs<TLeft, TRight> &
+  PipedPreAuthorize<TLeft, TRight> &
+  PipedLoadResources<TLeft, TRight> &
+  PipedFinalAuthorize<TLeft, TRight> &
+  PipedExecute<TLeft, TRight> &
+  PipedRedactResponse<TLeft, TRight>;
 
 function nonStageKeysOf(obj: Record<string, any>) {
   const out: Record<string, any> = {};
@@ -1006,6 +1030,91 @@ export function HTPipe<
     PipedRedactResponse<T3, PipedRedactResponse<T2, T1>>
   > &
   PipedPassthrough<T4, PipedPassthrough<T3, PipedPassthrough<T2, T1>>>;
+
+// five parameters with possibly added inputs
+export function HTPipe<
+  T5 extends AllStagesOptionalShape,
+  T4 extends AllStagesOptionalShape,
+  T3 extends AllStagesOptionalShape,
+  T2 extends AllStagesOptionalShape,
+  T1 extends AllStagesOptionalShape,
+>(
+  obj5: T5,
+  obj4: T4,
+  obj3: T3,
+  obj2: T2,
+  obj1: T1
+): PipedAll<T5, PipedAll<T4, PipedAll<T3, PipedAll<T2, T1>>>> &
+  PipedPassthroughAll<[T5, T4, T3, T2, T1]>;
+
+// six parameters with possibly added inputs
+export function HTPipe<
+  T6 extends AllStagesOptionalShape,
+  T5 extends AllStagesOptionalShape,
+  T4 extends AllStagesOptionalShape,
+  T3 extends AllStagesOptionalShape,
+  T2 extends AllStagesOptionalShape,
+  T1 extends AllStagesOptionalShape,
+>(
+  obj6: T6,
+  obj5: T5,
+  obj4: T4,
+  obj3: T3,
+  obj2: T2,
+  obj1: T1
+): PipedAll<T6, PipedAll<T5, PipedAll<T4, PipedAll<T3, PipedAll<T2, T1>>>>> &
+  PipedPassthroughAll<[T6, T5, T4, T3, T2, T1]>;
+
+// seven parameters with possibly added inputs
+export function HTPipe<
+  T7 extends AllStagesOptionalShape,
+  T6 extends AllStagesOptionalShape,
+  T5 extends AllStagesOptionalShape,
+  T4 extends AllStagesOptionalShape,
+  T3 extends AllStagesOptionalShape,
+  T2 extends AllStagesOptionalShape,
+  T1 extends AllStagesOptionalShape,
+>(
+  obj7: T7,
+  obj6: T6,
+  obj5: T5,
+  obj4: T4,
+  obj3: T3,
+  obj2: T2,
+  obj1: T1
+): PipedAll<
+  T7,
+  PipedAll<T6, PipedAll<T5, PipedAll<T4, PipedAll<T3, PipedAll<T2, T1>>>>>
+> &
+  PipedPassthroughAll<[T7, T6, T5, T4, T3, T2, T1]>;
+
+// eight parameters with possibly added inputs
+export function HTPipe<
+  T8 extends AllStagesOptionalShape,
+  T7 extends AllStagesOptionalShape,
+  T6 extends AllStagesOptionalShape,
+  T5 extends AllStagesOptionalShape,
+  T4 extends AllStagesOptionalShape,
+  T3 extends AllStagesOptionalShape,
+  T2 extends AllStagesOptionalShape,
+  T1 extends AllStagesOptionalShape,
+>(
+  obj8: T8,
+  obj7: T7,
+  obj6: T6,
+  obj5: T5,
+  obj4: T4,
+  obj3: T3,
+  obj2: T2,
+  obj1: T1
+): PipedAll<
+  T8,
+  PipedAll<
+    T7,
+    PipedAll<T6, PipedAll<T5, PipedAll<T4, PipedAll<T3, PipedAll<T2, T1>>>>>
+  >
+> &
+  PipedPassthroughAll<[T8, T7, T6, T5, T4, T3, T2, T1]>;
 
 export function HTPipe(...objs: any[]) {
   if (objs.length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
   AllStageKeys,
   AllStagesOptionalShape,
   HasExecute,
+  HasUnsafeSlices,
   HasExtractAmbient,
   HasExtractInputs,
   HasFinalAuthorize,
@@ -39,6 +40,7 @@ import {
   OptionallyHasRedactResponse,
   OptionallyHasSanitizeInputs,
   PromiseResolveOrSync,
+  UNSAFE_SLICES,
 } from './types.js';
 
 type FunctionTaking<TIn> = (param: TIn) => any;
@@ -178,26 +180,38 @@ export function SanitizeInputsFromTo<
   });
 }
 
-// Per-slot composer: writes to sanitizeInputs under a chosen key, preserving any other
-// slices already present. This restores per-slot ergonomics on top of the single-slot core.
-// Example: WithInputSlice('params', IdSchema.parse) becomes the new WithParamsSanitized.
-// Input type is intentionally loose (Record<string, any>) so multiple WithInputSlice mixins
-// can chain freely; the sanitizer enforces the slice's own runtime shape.
-export function WithInputSlice<
-  TSliceName extends string,
-  TUnsafeSlice,
-  TSafeSlice,
->(sliceName: TSliceName, sanitizer: (unsafeSlice: TUnsafeSlice) => TSafeSlice) {
+// Per-slice sanitization for HTTP-style handlers whose inputs are the
+// canonical { params, query, body, headers } object. Each named slice is
+// sanitized by its function; the RAW remainder travels to the next chained
+// sanitizer under UNSAFE_SLICES only — core deletes that key after the
+// sanitize stage, so ONLY explicitly-sanitized slices reach later stages
+// (want a raw slice through? say so: `{ query: (q) => q }`). Fragments chain
+// via HTPipe: a later fragment's slices are added (right wins on a clash,
+// re-sanitizing from the raw slice), and its output carries the union of all
+// named slices.
+export function SanitizeInputsSlices<
+  TSanitizers extends Record<string, (unsafeSlice: any) => any>,
+>(sanitizers: TSanitizers) {
+  type SafeSlices = {
+    [K in keyof TSanitizers]: ReturnType<TSanitizers[K]>;
+  };
   return SanitizeInputs(
-    (
-      unsafeInputs: Record<string, any>
-    ): {
-      [K in TSliceName]: TSafeSlice;
-    } & Record<string, any> => {
-      return {
-        ...unsafeInputs,
-        [sliceName]: sanitizer(unsafeInputs[sliceName] as TUnsafeSlice),
-      } as { [K in TSliceName]: TSafeSlice } & Record<string, any>;
+    (unsafeInputs: Record<string, any>): SafeSlices & HasUnsafeSlices => {
+      const chained =
+        unsafeInputs !== null &&
+        typeof unsafeInputs === 'object' &&
+        UNSAFE_SLICES in unsafeInputs;
+      // First fragment in a chain receives the raw inputs; later fragments
+      // receive the previous fragment's { ...safe, [UNSAFE_SLICES]: raw }.
+      const rawSlices: Record<string, any> = chained
+        ? (unsafeInputs as Record<PropertyKey, any>)[UNSAFE_SLICES]
+        : unsafeInputs;
+      const out: Record<PropertyKey, any> = chained ? { ...unsafeInputs } : {};
+      for (const sliceName of Object.keys(sanitizers)) {
+        out[sliceName] = sanitizers[sliceName](rawSlices[sliceName]);
+      }
+      out[UNSAFE_SLICES] = rawSlices;
+      return out as SafeSlices & HasUnsafeSlices;
     }
   );
 }
@@ -507,9 +521,8 @@ type PipedExtractInputs<TLeft, TRight> = [TLeft] extends [
     ? { extractInputs: TRight['extractInputs'] }
     : {};
 
-// Strips index signatures, keeping only statically-known keys. Needed because
-// slice-style sanitizers (WithInputSlice) return `{...} & Record<string, any>`,
-// and `Omit<X, keyof (Y & Record<string, any>)>` would omit EVERYTHING.
+// Strips index signatures, keeping only statically-known keys, so merging a
+// legacy `X & Record<string, any>`-shaped return can't omit everything.
 type KnownKeys<T> = {
   [K in keyof T as string extends K
     ? never
@@ -522,14 +535,18 @@ type KnownKeys<T> = {
 
 // Sanitize stages CHAIN (the right one consumes the left one's output), so the
 // composed return type depends on the right fragment's style:
-// - passthrough style (has an index signature, e.g. WithInputSlice): unknown
-//   keys flow through at runtime, so the left fragment's named keys survive —
-//   merge them in (right wins on clashes).
-// - full-replace style (no index signature): the right return describes the
+// - slice style (carries the UNSAFE_SLICES raw-remainder channel, i.e.
+//   SanitizeInputsSlices): the left fragment's named slices survive — merge
+//   them in (right wins on clashes).
+// - full-replace style (no UNSAFE_SLICES key): the right return describes the
 //   entire output; the left's keys are gone.
 type ChainedSanitizeReturn<TLeftReturn, TRightReturn> =
-  string extends keyof TRightReturn
-    ? TRightReturn & Omit<KnownKeys<TLeftReturn>, keyof KnownKeys<TRightReturn>>
+  typeof UNSAFE_SLICES extends keyof TRightReturn
+    ? TRightReturn &
+        Omit<
+          KnownKeys<Omit<TLeftReturn, typeof UNSAFE_SLICES>>,
+          keyof KnownKeys<TRightReturn>
+        >
     : TRightReturn;
 
 type PipedSanitizeInputs<TLeft, TRight> = [TLeft] extends [
@@ -1321,6 +1338,8 @@ export function HTPipe(...objs: any[]) {
   return objs.reduce((prev: any, curr: any) => HTPipe(prev, curr), {});
 }
 
+export { UNSAFE_SLICES } from './types.js';
+export type { HasUnsafeSlices, SanitizedOnly } from './types.js';
 export * from './core.js';
 export * from './errors.js';
 export * from './http-adapter.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -755,6 +755,34 @@ type ClashlessRedactResponse<_TLeft, TRight> = OptionallyHasRedactResponse<
     : any
 >;
 
+// Non-stage keys (e.g. the HTTP adapters' `responseMeta`) pass through HTPipe
+// untouched with right-wins semantics, so adapter-level configuration can live
+// on any fragment. Core stays ignorant of what the keys mean.
+type NonStageKeys<T> = Omit<KnownKeys<T>, AllStageKeys>;
+type PipedPassthrough<TLeft, TRight> = NonStageKeys<TRight> &
+  Omit<NonStageKeys<TLeft>, keyof NonStageKeys<TRight>>;
+
+const ALL_STAGE_KEYS: AllStageKeys[] = [
+  'extractAmbient',
+  'extractInputs',
+  'sanitizeInputs',
+  'preAuthorize',
+  'loadResources',
+  'finalAuthorize',
+  'execute',
+  'redactResponse',
+];
+
+function nonStageKeysOf(obj: Record<string, any>) {
+  const out: Record<string, any> = {};
+  for (const key of Object.keys(obj)) {
+    if (!(ALL_STAGE_KEYS as string[]).includes(key)) {
+      out[key] = obj[key];
+    }
+  }
+  return out;
+}
+
 // no parameter - returns empty object
 export function HTPipe(): {};
 
@@ -768,7 +796,7 @@ export function HTPipe<
     OptionallyHasFinalAuthorize<any, any> &
     OptionallyHasExecute<any, any> &
     OptionallyHasRedactResponse<any, any>,
->(obj: T): Pick<T, AllStageKeys>;
+>(obj: T): Pick<T, AllStageKeys> & NonStageKeys<T>;
 
 // two parameters with automatic type guessing of right - all or nothing!
 export function HTPipe<
@@ -823,7 +851,8 @@ export function HTPipe<
   PipedLoadResources<TLeft, TRight> &
   PipedFinalAuthorize<TLeft, TRight> &
   PipedExecute<TLeft, TRight> &
-  PipedRedactResponse<TLeft, TRight>;
+  PipedRedactResponse<TLeft, TRight> &
+  PipedPassthrough<TLeft, TRight>;
 
 // two parameters with possibly added inputs
 export function HTPipe<
@@ -853,7 +882,8 @@ export function HTPipe<
   PipedLoadResources<TLeft, TRight> &
   PipedFinalAuthorize<TLeft, TRight> &
   PipedExecute<TLeft, TRight> &
-  PipedRedactResponse<TLeft, TRight>;
+  PipedRedactResponse<TLeft, TRight> &
+  PipedPassthrough<TLeft, TRight>;
 
 // three parameters with possibly added inputs
 export function HTPipe<
@@ -892,7 +922,8 @@ export function HTPipe<
   PipedLoadResources<T3, PipedLoadResources<T2, T1>> &
   PipedFinalAuthorize<T3, PipedFinalAuthorize<T2, T1>> &
   PipedExecute<T3, PipedExecute<T2, T1>> &
-  PipedRedactResponse<T3, PipedRedactResponse<T2, T1>>;
+  PipedRedactResponse<T3, PipedRedactResponse<T2, T1>> &
+  PipedPassthrough<T3, PipedPassthrough<T2, T1>>;
 
 // four parameters with possibly added inputs
 export function HTPipe<
@@ -970,7 +1001,11 @@ export function HTPipe<
     PipedFinalAuthorize<T3, PipedFinalAuthorize<T2, T1>>
   > &
   PipedExecute<T4, PipedExecute<T3, PipedExecute<T2, T1>>> &
-  PipedRedactResponse<T4, PipedRedactResponse<T3, PipedRedactResponse<T2, T1>>>;
+  PipedRedactResponse<
+    T4,
+    PipedRedactResponse<T3, PipedRedactResponse<T2, T1>>
+  > &
+  PipedPassthrough<T4, PipedPassthrough<T3, PipedPassthrough<T2, T1>>>;
 
 export function HTPipe(...objs: any[]) {
   if (objs.length === 0) {
@@ -983,6 +1018,10 @@ export function HTPipe(...objs: any[]) {
     const left = objs[0];
     const right = objs[1];
     return {
+      // Non-stage keys (adapter config like responseMeta) pass through,
+      // right-wins. Stage keys are rebuilt below and never leak through here.
+      ...nonStageKeysOf(left),
+      ...nonStageKeysOf(right),
       ...((isHasExtractAmbient(left) && isHasExtractAmbient(right)
         ? {
             extractAmbient: (context: any) => {

--- a/src/lifecycle-functions.ts
+++ b/src/lifecycle-functions.ts
@@ -60,8 +60,11 @@ export function Execute<TContextIn extends object, TUnsafeResponse>(
   };
 }
 
-export function RedactResponse<TUnsafeResponse, TResponse>(
-  projector: (unsafe: TUnsafeResponse) => TResponse
+// The projector may take the final lifecycle context as an optional second
+// argument (e.g. to redact by caller role); one-parameter projectors work
+// unchanged.
+export function RedactResponse<TUnsafeResponse, TResponse, TContext = any>(
+  projector: (unsafe: TUnsafeResponse, context?: TContext) => TResponse
 ) {
   return {
     redactResponse: projector,

--- a/src/mongoose.ts
+++ b/src/mongoose.ts
@@ -18,6 +18,18 @@ interface ModelWithFindOne<TInstance = any> {
   findOne(options: any): { exec(): Promise<TInstance> };
 }
 
+interface ModelWithFind<TInstance = any> {
+  find(filter: any): { exec(): Promise<TInstance[]> };
+}
+
+// The context contribution/requirement for tenant-scoped list endpoints: some
+// fragment contributes `queryScope` (a mongo filter restricting what the
+// caller may see) and the scoped finders below type-REQUIRE it, so forgetting
+// the scope is a compile error instead of a cross-tenant data leak.
+export interface HasQueryScope {
+  queryScope: Record<string, unknown>;
+}
+
 interface HasValidateSync {
   validateSync(paths?: any, options?: any): { errors: any[] };
 }
@@ -161,6 +173,37 @@ export function htMongooseFactory(mongoose: any) {
     );
   }
 
+  // Execute fragment for list endpoints: runs Model.find with the composed
+  // filter `{ ...ctx.queryScope, ...extraFilter }`. `queryScope` is REQUIRED
+  // in the context type, so the deps-met machinery forces some earlier
+  // fragment (e.g. a LoadResources contributing the caller's tenant filter)
+  // to provide it — authorization-as-query-scope by construction.
+  function findScoped(Model: ModelWithFind, extraFilter?: object) {
+    return Execute(async (context: HasQueryScope) => {
+      return await Model.find({
+        ...context.queryScope,
+        ...(extraFilter || {}),
+      }).exec();
+    });
+  }
+
+  // LoadResources variant of findScoped for handlers that post-process the
+  // scoped rows in their own execute stage; stores them under `docsKey`.
+  function loadScopedTo(
+    Model: ModelWithFind,
+    docsKey: string,
+    extraFilter?: object
+  ) {
+    return LoadResources(async (context: HasQueryScope) => {
+      return {
+        [docsKey]: await Model.find({
+          ...context.queryScope,
+          ...(extraFilter || {}),
+        }).exec(),
+      };
+    });
+  }
+
   function SaveOnDocumentFrom(propertyKeyOfDocument: string) {
     return Execute(async (context: any) => {
       if (context[propertyKeyOfDocument]) {
@@ -235,6 +278,8 @@ export function htMongooseFactory(mongoose: any) {
     dtoSchemaObj,
     findByIdRequired,
     findOneByRequired,
+    findScoped,
+    loadScopedTo,
     stripIdTransform,
   };
 }

--- a/src/mongoose.ts
+++ b/src/mongoose.ts
@@ -1,5 +1,5 @@
 import { HipBadInputs, HipNotFound } from './errors.js';
-import { WithInputSlice } from './index.js';
+import { SanitizeInputsSlices } from './index.js';
 import {
   Execute,
   LoadResources,
@@ -142,56 +142,47 @@ export function htMongooseFactory(mongoose: any) {
     });
   }
 
-  // Per-slice mongoose validation; composes via WithInputSlice for per-slot ergonomics.
-  // Example: SanitizeInputsSliceWithMongoose('params', ThingByIdParamFactory)
-  function SanitizeInputsSliceWithMongoose<
-    TSliceName extends string,
-    TSafeSlice extends ReturnType<TInstance['toObject']>,
-    TDocFactory extends DocumentFactory<any>,
-    TInstance extends ReturnType<TDocFactory>,
-    TUnsafeSlice extends object,
-  >(
-    sliceName: TSliceName,
-    DocFactory: TDocFactory,
-    options?: { validateModifiedOnly?: boolean }
-  ) {
-    return WithInputSlice<TSliceName, TUnsafeSlice, TSafeSlice>(
-      sliceName,
-      (unsafeSlice: TUnsafeSlice) => {
-        const doc = DocFactory(unsafeSlice);
-        const validateErrors = doc.validateSync(
-          undefined,
-          options?.validateModifiedOnly
-            ? { validateModifiedOnly: true }
-            : undefined
-        );
-        if (validateErrors !== undefined) {
-          throw new HipBadInputs(`${sliceName} not valid`);
-        }
-        return doc.toObject({ transform: stripIdTransform }) as TSafeSlice;
-      }
-    );
+  // Per-slice mongoose validation for one or more named slices; composes via
+  // SanitizeInputsSlices, so only explicitly-sanitized slices survive the
+  // sanitize stage. Example:
+  //   SanitizeInputsSlicesWithMongoose({ params: ThingByIdParamFactory })
+  function SanitizeInputsSlicesWithMongoose<
+    TFactories extends Record<string, DocumentFactory<any>>,
+  >(factories: TFactories, options?: { validateModifiedOnly?: boolean }) {
+    const sanitizers = Object.fromEntries(
+      Object.keys(factories).map((sliceName) => [
+        sliceName,
+        (unsafeSlice: unknown) => {
+          const doc = factories[sliceName](unsafeSlice);
+          const validateErrors = doc.validateSync(
+            undefined,
+            options?.validateModifiedOnly
+              ? { validateModifiedOnly: true }
+              : undefined
+          );
+          if (validateErrors !== undefined) {
+            throw new HipBadInputs(`${sliceName} not valid`);
+          }
+          return doc.toObject({ transform: stripIdTransform });
+        },
+      ])
+    ) as {
+      [K in keyof TFactories & string]: (
+        unsafeSlice: unknown
+      ) => ReturnType<ReturnType<TFactories[K]>['toObject']>;
+    };
+    return SanitizeInputsSlices(sanitizers);
   }
 
-  // Execute fragment for list endpoints: runs Model.find with the composed
-  // filter `{ ...ctx.queryScope, ...extraFilter }`. `queryScope` is REQUIRED
-  // in the context type, so the deps-met machinery forces some earlier
-  // fragment (e.g. a LoadResources contributing the caller's tenant filter)
-  // to provide it — authorization-as-query-scope by construction.
-  function findScoped(Model: ModelWithFind, extraFilter?: object) {
-    return Execute(async (context: HasQueryScope) => {
-      return await Model.find({
-        ...context.queryScope,
-        ...(extraFilter || {}),
-      }).exec();
-    });
-  }
-
-  // LoadResources variant of findScoped for handlers that post-process the
-  // scoped rows in their own execute stage; stores them under `docsKey`.
-  function loadScopedTo(
+  // LoadResources fragment: fetches Model.find with the composed filter
+  // `{ ...ctx.queryScope, ...extraFilter }` and stores the rows under
+  // `docsKey`. `queryScope` is REQUIRED in the context type, so the deps-met
+  // machinery forces some earlier fragment (e.g. a LoadResources contributing
+  // the caller's tenant filter) to provide it — authorization-as-query-scope
+  // by construction.
+  function loadScopedTo<TKey extends string>(
     Model: ModelWithFind,
-    docsKey: string,
+    docsKey: TKey,
     extraFilter?: object
   ) {
     return LoadResources(async (context: HasQueryScope) => {
@@ -200,8 +191,25 @@ export function htMongooseFactory(mongoose: any) {
           ...context.queryScope,
           ...(extraFilter || {}),
         }).exec(),
-      };
+      } as Record<TKey, any[]>;
     });
+  }
+
+  // The plain list endpoint in one fragment: loadScopedTo on the load stage
+  // (so the rows sit in context for finalAuthorize / redactResponse /
+  // downstream execute stages) plus a trivial execute that returns them.
+  // Fetching lives on the LOAD stage — piping your own execute after this one
+  // overrides the response without re-running or wasting the query.
+  function findScoped<TKey extends string = 'scopedDocs'>(
+    Model: ModelWithFind,
+    extraFilter?: object,
+    docsKey?: TKey
+  ) {
+    const key = (docsKey ?? 'scopedDocs') as TKey;
+    return {
+      ...loadScopedTo(Model, key, extraFilter),
+      ...Execute((context: Record<TKey, any[]>) => context[key]),
+    };
   }
 
   function SaveOnDocumentFrom(propertyKeyOfDocument: string) {
@@ -268,7 +276,7 @@ export function htMongooseFactory(mongoose: any) {
 
   return {
     SanitizeInputsWithMongoose,
-    SanitizeInputsSliceWithMongoose,
+    SanitizeInputsSlicesWithMongoose,
     PojoToDocument,
     RedactResponseWithMongoose,
     UpdateDocumentFromTo,

--- a/src/next.ts
+++ b/src/next.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server.js';
 import { executeHipthrustable } from './core.js';
-import { hipErrorToStatus, HipRedirect, isHipError } from './errors.js';
+import {
+  hipErrorToBody,
+  hipErrorToStatus,
+  HipRedirect,
+  isHipError,
+} from './errors.js';
 import {
   composeHttpHipthrustable,
   HasResponseMeta,
@@ -154,10 +159,9 @@ export function toNextHandler<
           code as 301 | 302 | 303 | 307 | 308
         );
       } else if (isHipError(exception)) {
-        return NextResponse.json(
-          { error: exception.message },
-          { status: hipErrorToStatus(exception) }
-        );
+        return NextResponse.json(hipErrorToBody(exception), {
+          status: hipErrorToStatus(exception),
+        });
       }
       return NextResponse.json(
         { error: 'Internal server error' },

--- a/src/next.ts
+++ b/src/next.ts
@@ -6,12 +6,16 @@ import {
   HipRedirect,
   isHipError,
 } from './errors.js';
+import { HipBadInputs } from './errors.js';
 import {
   composeHttpHipthrustable,
   HasResponseMeta,
+  HttpAdapterOptions,
   HttpHandlerConfig,
   HttpRawInputs,
   resolveResponseMeta,
+  safeInvokeAfterResponse,
+  safeInvokeOnError,
 } from './http-adapter.js';
 import {
   ExecuteDepsMet,
@@ -36,12 +40,15 @@ export interface NextRaw extends HttpRawInputs {
   [key: string]: unknown;
 }
 
-export interface HipNextHandlerOptions {
+export interface HipNextHandlerOptions extends HttpAdapterOptions {
   // Async setup run before the lifecycle; its result is merged into the raw
   // envelope so the handler's extractAmbient can read it (e.g. auth principal).
   gatherContext?: (req: NextRequest) => Promise<Record<string, unknown>>;
-  // Scheduled via Next's `after()` to run once the response is sent.
-  afterResponse?: () => void;
+  // A non-empty request body that fails to parse as JSON responds 422 by
+  // default (previously it silently became `{}`, which lets garbage bodies
+  // "succeed" against fully-optional schemas). Set true to restore the old
+  // coerce-to-{} behavior.
+  allowMalformedBody?: boolean;
 }
 
 const BODYLESS_METHODS = ['GET', 'HEAD', 'DELETE'];
@@ -105,22 +112,21 @@ export function toNextHandler<
     req: NextRequest,
     routeContext?: NextRouteContext
   ): Promise<NextResponse> => {
+    let raw: NextRaw | undefined;
     try {
-      if (options.afterResponse) {
-        try {
-          const { after } = await import('next/server.js');
-          after(options.afterResponse);
-        } catch {
-          // `after` unavailable (older Next.js); skip scheduling.
-        }
-      }
-
       let body: any = {};
       if (!BODYLESS_METHODS.includes(req.method)) {
-        try {
-          body = await req.json();
-        } catch {
-          body = {};
+        const text = await req.text();
+        if (text.trim() !== '') {
+          try {
+            body = JSON.parse(text);
+          } catch {
+            if (options.allowMalformedBody) {
+              body = {};
+            } else {
+              throw new HipBadInputs('Malformed JSON body');
+            }
+          }
         }
       }
 
@@ -131,7 +137,7 @@ export function toNextHandler<
         ? await options.gatherContext(req)
         : {};
 
-      const raw: NextRaw = {
+      raw = {
         req,
         params,
         query,
@@ -144,12 +150,29 @@ export function toNextHandler<
         fullHipthrustable as any,
         raw
       );
+      if (options.afterResponse) {
+        // Scheduled AFTER the lifecycle resolves so the callback receives the
+        // final context, via Next's `after()` (runs once the response is
+        // sent). Failed requests never fire it.
+        const runAfterResponse = () =>
+          safeInvokeAfterResponse(options.afterResponse, context);
+        try {
+          const { after } = await import('next/server.js');
+          after(runAfterResponse);
+        } catch {
+          // `after` unavailable (older Next.js); run fire-and-forget instead.
+          runAfterResponse();
+        }
+      }
       const meta = resolveResponseMeta(responseMeta, context);
       return NextResponse.json(response, {
         status: meta.status || 200,
         headers: meta.headers,
       });
     } catch (exception) {
+      if (!(exception instanceof HipRedirect)) {
+        safeInvokeOnError(options.onError, exception, { raw });
+      }
       if (exception instanceof HipRedirect) {
         const code = REDIRECT_CODES.includes(exception.redirectCode)
           ? exception.redirectCode

--- a/src/trpc.ts
+++ b/src/trpc.ts
@@ -73,7 +73,15 @@ type TrpcHandlerConfig<
       Awaited<TLoadResourcesOut> &
       Awaited<TFinalAuthOut>
   ) => PromiseOrSync<TUnsafeResponse>;
-  redactResponse: (unsafe: Awaited<TUnsafeResponse>) => TResponse;
+  redactResponse: (
+    unsafe: Awaited<TUnsafeResponse>,
+    context: { inputs: Awaited<TSafeInputs> } & ([TAmbient] extends [never]
+      ? {}
+      : { ambient: TAmbient }) &
+      Awaited<TPreAuthOut> &
+      Awaited<TLoadResourcesOut> &
+      Awaited<TFinalAuthOut>
+  ) => TResponse;
 };
 
 type InferredTrpcConfig = OptionalStagesShape & HasRequiredStages;

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,6 +131,35 @@ type IntersectProperties<T extends object> = keyof T extends never
     ? A
     : never;
 
+// The canonical any-detection trick: `any` is the only type where `0 extends 1 & T`.
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+// Resolved (unmet) constraint marker. Instead of collapsing the whole deps-met
+// intersection to `never` — which makes TS report the useless "not assignable
+// to parameter of type 'never'" — an unmet dependency resolves to this branded
+// type, so the compiler error names the consuming stage and the missing
+// context key.
+export interface HipDepNotMet<TStage extends string, TKey> {
+  __hipDepNotMet: [TStage, TKey];
+}
+
+// A stage's (promise-resolved) return type, or `never` when the stage is
+// absent/optional on T.
+type StageReturnOf<T, K extends AllStageKeys> =
+  T extends Record<K, (...args: any[]) => infer R>
+    ? PromiseResolveOrSync<R>
+    : never;
+
+// Does any union member of TReturn carry TKey with a TValue-compatible value?
+// Distributing via Extract (a) tolerates conditional stage returns like
+// `{} | { doc: Doc }`, and (b) naturally ignores the `false` members of
+// authorization-stage returns.
+type ProvidesKey<TReturn, TKey extends PropertyKey, TValue> = [
+  Extract<TReturn, Record<TKey, TValue>>,
+] extends [never]
+  ? false
+  : true;
+
 type ReturnedTypeUpToPreAuthorize<TValue, TKey> = TKey extends 'inputs'
   ? HasSanitizeInputs<any, TValue>
   : TKey extends 'ambient'
@@ -153,9 +182,16 @@ type ReturnedSomewhereUpToLoadResources<
   TOut,
   TValue,
   TKey extends string | symbol | number,
-> = [TOut] extends [HasPreAuthorize<any, Record<TKey, TValue>>]
-  ? HasPreAuthorize<any, Record<TKey, TValue>>
-  : never;
+> =
+  IsAny<TValue> extends true
+    ? {}
+    : ProvidesKey<
+          StageReturnOf<TOut, 'preAuthorize'>,
+          TKey,
+          TValue
+        > extends true
+      ? {}
+      : HipDepNotMet<'loadResources', TKey>;
 
 type AllInitKeys = 'ambient' | 'inputs';
 
@@ -173,11 +209,22 @@ type ReturnedSomewhereUpToFinalAuthorize<
   TOut,
   TValue,
   TKey extends string | symbol | number,
-> = [TOut] extends [HasLoadResources<any, Record<TKey, TValue>>]
-  ? HasLoadResources<any, Record<TKey, TValue>>
-  : [TOut] extends [HasPreAuthorize<any, Record<TKey, TValue>>]
-    ? HasPreAuthorize<any, Record<TKey, TValue>>
-    : never;
+> =
+  IsAny<TValue> extends true
+    ? {}
+    : ProvidesKey<
+          StageReturnOf<TOut, 'loadResources'>,
+          TKey,
+          TValue
+        > extends true
+      ? {}
+      : ProvidesKey<
+            StageReturnOf<TOut, 'preAuthorize'>,
+            TKey,
+            TValue
+          > extends true
+        ? {}
+        : HipDepNotMet<'finalAuthorize', TKey>;
 
 export type FinalAuthorizeDepsMet<T extends HasFinalAuthorize<any, any>> =
   IntersectProperties<{
@@ -198,13 +245,29 @@ type ReturnedSomewhereUpToExecute<
   TOut,
   TValue,
   TKey extends string | symbol | number,
-> = [TOut] extends [HasFinalAuthorize<any, Record<TKey, TValue>>]
-  ? HasFinalAuthorize<any, Record<TKey, TValue>>
-  : [TOut] extends [HasLoadResources<any, Record<TKey, TValue>>]
-    ? HasLoadResources<any, Record<TKey, TValue>>
-    : [TOut] extends [HasPreAuthorize<any, Record<TKey, TValue>>]
-      ? HasPreAuthorize<any, Record<TKey, TValue>>
-      : never;
+  TStage extends string = 'execute',
+> =
+  IsAny<TValue> extends true
+    ? {}
+    : ProvidesKey<
+          StageReturnOf<TOut, 'finalAuthorize'>,
+          TKey,
+          TValue
+        > extends true
+      ? {}
+      : ProvidesKey<
+            StageReturnOf<TOut, 'loadResources'>,
+            TKey,
+            TValue
+          > extends true
+        ? {}
+        : ProvidesKey<
+              StageReturnOf<TOut, 'preAuthorize'>,
+              TKey,
+              TValue
+            > extends true
+          ? {}
+          : HipDepNotMet<TStage, TKey>;
 
 export type ExecuteDepsMet<T> = IntersectProperties<{
   [P in keyof OptionalExecuteParams<T>]: [P] extends [AllInitKeys]
@@ -212,11 +275,12 @@ export type ExecuteDepsMet<T> = IntersectProperties<{
     : ReturnedSomewhereUpToExecute<T, OptionalExecuteParams<T>[P], P>;
 }>;
 
-type ReturnedSomewhereUpToRedactResponse<TOut, TValue> = [TOut] extends [
-  HasExecute<any, TValue>,
-]
-  ? HasExecute<any, TValue>
-  : never;
+type ReturnedSomewhereUpToRedactResponse<TOut, TValue> =
+  IsAny<TValue extends Record<any, infer V> ? V : never> extends true
+    ? {}
+    : [Extract<StageReturnOf<TOut, 'execute'>, TValue>] extends [never]
+      ? HipDepNotMet<'redactResponse', keyof TValue>
+      : {};
 
 // Infers the declared type of a redactor's optional context parameter; for a
 // one-parameter redactor this resolves to `unknown` (no context requirements).
@@ -241,5 +305,10 @@ export type RedactResponseDepsMet<T extends HasRedactResponse<any, any>> =
     IntersectProperties<{
       [P in keyof RedactResponseCtxParam<T>]: [P] extends [AllInitKeys]
         ? ReturnedTypeUpToPreAuthorize<RedactResponseCtxParam<T>[P], P>
-        : ReturnedSomewhereUpToExecute<T, RedactResponseCtxParam<T>[P], P>;
+        : ReturnedSomewhereUpToExecute<
+            T,
+            RedactResponseCtxParam<T>[P],
+            P,
+            'redactResponse'
+          >;
     }>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,12 +68,18 @@ export interface HasExecute<TContextIn, TUnsafeResponse> {
   execute: (context: TContextIn) => PromiseOrSync<TUnsafeResponse>;
 }
 
+// The second parameter is the final lifecycle context (everything execute
+// saw), so redaction can depend on e.g. the caller's role without smuggling
+// authz flags through the execute return value. The runtime always passes it;
+// it is declared optional so existing one-argument call sites keep compiling,
+// and TS's parameter-optionality laxity means two-parameter redactors with a
+// required, precisely-typed context still satisfy the shape.
 export interface OptionallyHasRedactResponse<TUnsafeResponse, TResponse> {
-  redactResponse?: (unsafe: TUnsafeResponse) => TResponse;
+  redactResponse?: (unsafe: TUnsafeResponse, context?: any) => TResponse;
 }
 
 export interface HasRedactResponse<TUnsafeResponse, TResponse> {
-  redactResponse: (unsafe: TUnsafeResponse) => TResponse;
+  redactResponse: (unsafe: TUnsafeResponse, context?: any) => TResponse;
 }
 
 export type HasRequiredStages = HasSanitizeInputs<any, any> &
@@ -212,6 +218,14 @@ type ReturnedSomewhereUpToRedactResponse<TOut, TValue> = [TOut] extends [
   ? HasExecute<any, TValue>
   : never;
 
+// Infers the declared type of a redactor's optional context parameter; for a
+// one-parameter redactor this resolves to `unknown` (no context requirements).
+type RedactResponseCtxParam<T> = T extends {
+  redactResponse: (unsafe: any, context: infer C) => any;
+}
+  ? C
+  : unknown;
+
 export type RedactResponseDepsMet<T extends HasRedactResponse<any, any>> =
   IntersectProperties<{
     [P in keyof Parameters<
@@ -220,4 +234,12 @@ export type RedactResponseDepsMet<T extends HasRedactResponse<any, any>> =
       T,
       Record<P, Parameters<T['redactResponse']>[0][P]>
     >;
-  }>;
+  }> &
+    // A two-parameter redactor's declared context keys participate in the
+    // deps-met machinery like execute's do (the runtime passes execute's
+    // context to redactResponse).
+    IntersectProperties<{
+      [P in keyof RedactResponseCtxParam<T>]: [P] extends [AllInitKeys]
+        ? ReturnedTypeUpToPreAuthorize<RedactResponseCtxParam<T>[P], P>
+        : ReturnedSomewhereUpToExecute<T, RedactResponseCtxParam<T>[P], P>;
+    }>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,30 @@
 export type Constructor<T = {}> = new (...args: any[]) => T;
 
+// The out-of-band channel slice-style sanitizers use to hand the raw,
+// not-yet-sanitized remainder to the next sanitizer in a chain. Core DELETES
+// this key after the sanitize stage, so raw input can flow BETWEEN chained
+// sanitizers but can never reach preAuthorize or anything after it — nothing
+// survives sanitization except what a sanitizer explicitly returned.
+// Symbol.for() so the marker survives dual-package (ESM+CJS) loading; the
+// unique-symbol assertion lets it be used as a literal key in types.
+export const UNSAFE_SLICES: unique symbol = Symbol.for(
+  'hipthrusts.unsafeSlices'
+) as never;
+
+// The type-level face of the raw-remainder channel. A named interface (rather
+// than an inline computed symbol key) so declaration emit in dependent
+// modules can reference it.
+export interface HasUnsafeSlices {
+  [UNSAFE_SLICES]: Record<string, any>;
+}
+
+// What downstream stages actually see as `ctx.inputs`: the sanitize output
+// minus the raw-remainder channel (core strips it at runtime; this strips it
+// from the type).
+export type SanitizedOnly<T> = T extends object
+  ? Omit<T, typeof UNSAFE_SLICES>
+  : T;
+
 export type PromiseOrSync<T> = Promise<T> | T;
 export type PromiseResolveOrSync<T> = T extends Promise<infer U> ? U : T;
 

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { HipBadInputs, HipInternal } from './errors.js';
-import { WithInputSlice } from './index.js';
+import { SanitizeInputsSlices } from './index.js';
 import {
   LoadResources,
   RedactResponse,
@@ -27,59 +27,30 @@ export function htZodFactory() {
     });
   }
 
-  function SanitizeInputsSliceWithZod<
-    TSliceName extends string,
-    TSafeSlice extends z.infer<TSchema>,
-    TSchema extends z.ZodType<any, any, any>,
-    TUnsafeSlice extends object,
-  >(sliceName: TSliceName, schema: TSchema, options?: { partial?: boolean }) {
-    const effectiveSchema =
-      options?.partial && (schema as any).partial
-        ? (schema as any).partial()
-        : schema;
-
-    return WithInputSlice<TSliceName, TUnsafeSlice, TSafeSlice>(
-      sliceName,
-      (unsafeSlice: TUnsafeSlice) => {
-        const parseResult = effectiveSchema.safeParse(unsafeSlice);
-        if (!parseResult.success) {
-          throw new HipBadInputs(`${sliceName} not valid`, parseResult.error);
-        }
-        return stripIdTransform(parseResult.data) as TSafeSlice;
-      }
-    );
-  }
-
-  // Validates several slices in ONE sanitize fragment. Prefer this over piping
-  // multiple SanitizeInputsSliceWithZod fragments when validating e.g. params
-  // AND body: the return type names every slice key explicitly.
-  // Unvalidated slices pass through untouched (Record<string, any> absorbs them).
+  // Validates one or more named slices in a single fragment; each slice key
+  // is named in the return type. Built on SanitizeInputsSlices, so only the
+  // slices you name here (or in other chained sanitize fragments) survive to
+  // later stages — unvalidated slices are dropped after the sanitize stage.
   function SanitizeInputsSlicesWithZod<
     TShapes extends Record<string, z.ZodType<any, any, any>>,
   >(shapes: TShapes) {
-    return SanitizeInputs(
-      (
-        unsafeInputs: Record<string, any>
-      ): { [K in keyof TShapes]: z.output<TShapes[K]> } & Record<
-        string,
-        any
-      > => {
-        const out: Record<string, any> = { ...unsafeInputs };
-        for (const sliceName of Object.keys(shapes)) {
-          const parseResult = shapes[sliceName].safeParse(
-            unsafeInputs[sliceName]
-          );
+    const sanitizers = Object.fromEntries(
+      Object.keys(shapes).map((sliceName) => [
+        sliceName,
+        (unsafeSlice: unknown) => {
+          const parseResult = shapes[sliceName].safeParse(unsafeSlice);
           if (!parseResult.success) {
             throw new HipBadInputs(`${sliceName} not valid`, parseResult.error);
           }
-          out[sliceName] = stripIdTransform(parseResult.data);
-        }
-        return out as { [K in keyof TShapes]: z.output<TShapes[K]> } & Record<
-          string,
-          any
-        >;
-      }
-    );
+          return stripIdTransform(parseResult.data);
+        },
+      ])
+    ) as {
+      [K in keyof TShapes & string]: (
+        unsafeSlice: unknown
+      ) => z.output<TShapes[K]>;
+    };
+    return SanitizeInputsSlices(sanitizers);
   }
 
   function RedactResponseWithZod<
@@ -113,7 +84,6 @@ export function htZodFactory() {
 
   return {
     SanitizeInputsWithZod,
-    SanitizeInputsSliceWithZod,
     SanitizeInputsSlicesWithZod,
     RedactResponseWithZod,
     PojoToValidated,

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -50,6 +50,38 @@ export function htZodFactory() {
     );
   }
 
+  // Validates several slices in ONE sanitize fragment. Prefer this over piping
+  // multiple SanitizeInputsSliceWithZod fragments when validating e.g. params
+  // AND body: the return type names every slice key explicitly.
+  // Unvalidated slices pass through untouched (Record<string, any> absorbs them).
+  function SanitizeInputsSlicesWithZod<
+    TShapes extends Record<string, z.ZodType<any, any, any>>,
+  >(shapes: TShapes) {
+    return SanitizeInputs(
+      (
+        unsafeInputs: Record<string, any>
+      ): { [K in keyof TShapes]: z.output<TShapes[K]> } & Record<
+        string,
+        any
+      > => {
+        const out: Record<string, any> = { ...unsafeInputs };
+        for (const sliceName of Object.keys(shapes)) {
+          const parseResult = shapes[sliceName].safeParse(
+            unsafeInputs[sliceName]
+          );
+          if (!parseResult.success) {
+            throw new HipBadInputs(`${sliceName} not valid`, parseResult.error);
+          }
+          out[sliceName] = stripIdTransform(parseResult.data);
+        }
+        return out as { [K in keyof TShapes]: z.output<TShapes[K]> } & Record<
+          string,
+          any
+        >;
+      }
+    );
+  }
+
   function RedactResponseWithZod<
     TSafeResponse extends z.infer<TSchema>,
     TSchema extends z.ZodType<any, any, any>,
@@ -82,6 +114,7 @@ export function htZodFactory() {
   return {
     SanitizeInputsWithZod,
     SanitizeInputsSliceWithZod,
+    SanitizeInputsSlicesWithZod,
     RedactResponseWithZod,
     PojoToValidated,
     stripIdTransform,

--- a/test/composition.test-d.ts
+++ b/test/composition.test-d.ts
@@ -1,14 +1,14 @@
 // Type-level tests for HTPipe composition (Finding P0-1 / P1-7).
 // Run via `vitest --typecheck` (enabled in vitest.config.ts).
 import { describe, expectTypeOf, it } from 'vitest';
-import { HTPipe, WithInputSlice } from '../src/index.js';
+import { HTPipe, SanitizeInputsSlices } from '../src/index.js';
 import { toNextHandler } from '../src/next.js';
 
 describe('HTPipe sanitizeInputs composition (P0-1)', () => {
-  it('keeps both slices visible after piping two WithInputSlice fragments', () => {
+  it('keeps both slices visible after piping two SanitizeInputsSlices fragments', () => {
     const piped = HTPipe(
-      WithInputSlice('params', (p: any) => ({ id: String(p.id) })),
-      WithInputSlice('body', (b: any) => ({ name: String(b.name) }))
+      SanitizeInputsSlices({ params: (p: any) => ({ id: String(p.id) }) }),
+      SanitizeInputsSlices({ body: (b: any) => ({ name: String(b.name) }) })
     );
     type SanitizedOut = ReturnType<(typeof piped)['sanitizeInputs']>;
     expectTypeOf<SanitizedOut['params']>().toEqualTypeOf<{ id: string }>();
@@ -21,8 +21,8 @@ describe('HTPipe sanitizeInputs composition (P0-1)', () => {
     // (keeping only the right fragment's return), so this failed to typecheck.
     const handler = toNextHandler(
       HTPipe(
-        WithInputSlice('params', (p: any) => ({ id: String(p.id) })),
-        WithInputSlice('body', (b: any) => ({ name: String(b.name) })),
+        SanitizeInputsSlices({ params: (p: any) => ({ id: String(p.id) }) }),
+        SanitizeInputsSlices({ body: (b: any) => ({ name: String(b.name) }) }),
         {
           preAuthorize: () => true,
           loadResources: async (ctx: {
@@ -42,7 +42,7 @@ describe('HTPipe sanitizeInputs composition (P0-1)', () => {
 
   it('full-replace sanitizer on the right does not inherit left keys', () => {
     const piped = HTPipe(
-      WithInputSlice('params', (p: any) => ({ id: String(p.id) })),
+      SanitizeInputsSlices({ params: (p: any) => ({ id: String(p.id) }) }),
       { sanitizeInputs: (_all: any) => ({ replaced: true as const }) }
     );
     type SanitizedOut = ReturnType<(typeof piped)['sanitizeInputs']>;
@@ -70,8 +70,8 @@ describe('HTPipe non-stage key passthrough (P0-2)', () => {
 describe('HTPipe arity beyond 4 (P1-7)', () => {
   it('composes 6 fragments where the 6th consumes context from fragments 1-5', () => {
     const piped = HTPipe(
-      WithInputSlice('params', (p: any) => ({ id: String(p.id) })),
-      WithInputSlice('body', (b: any) => ({ name: String(b.name) })),
+      SanitizeInputsSlices({ params: (p: any) => ({ id: String(p.id) }) }),
+      SanitizeInputsSlices({ body: (b: any) => ({ name: String(b.name) }) }),
       { preAuthorize: () => ({ role: 'admin' as const }) },
       {
         loadResources: (ctx: { inputs: { params: { id: string } } }) => ({
@@ -138,5 +138,43 @@ describe('redactResponse context deps-met (P2-11)', () => {
         ctx: { canSeeEmails: boolean }
       ) => (ctx.canSeeEmails ? unsafe.rows : []),
     });
+  });
+});
+
+describe('strict sanitization (unsanitized slices are compile errors downstream)', () => {
+  it('consuming an unsanitized slice in a later stage fails deps-met', () => {
+    // `query` was never sanitized, so ctx.inputs has no `query` key (the raw
+    // remainder rides UNSAFE_SLICES and core strips it).
+    const piped = HTPipe(
+      SanitizeInputsSlices({ params: (p: any) => ({ id: String(p.id) }) }),
+      {
+        preAuthorize: () => true,
+        finalAuthorize: () => true,
+        execute: (ctx: { inputs: { query: { foo: string } } }) =>
+          ctx.inputs.query,
+        redactResponse: (u: unknown) => u,
+      }
+    );
+    // @ts-expect-error - consuming an unsanitized slice must not compile
+    toNextHandler(piped);
+  });
+
+  it('an explicit no-op slice types the raw slice through', () => {
+    const piped = HTPipe(
+      SanitizeInputsSlices({
+        params: (p: any) => ({ id: String(p.id) }),
+        query: (q: any) => q as Record<string, string>,
+      }),
+      {
+        preAuthorize: () => true,
+        finalAuthorize: () => true,
+        execute: (ctx: {
+          inputs: { params: { id: string }; query: Record<string, string> };
+        }) => ctx.inputs,
+        redactResponse: (u: unknown) => u,
+      }
+    );
+    const handler = toNextHandler(piped);
+    expectTypeOf(handler).toBeFunction();
   });
 });

--- a/test/composition.test-d.ts
+++ b/test/composition.test-d.ts
@@ -66,3 +66,52 @@ describe('HTPipe non-stage key passthrough (P0-2)', () => {
     expectTypeOf(piped.responseMeta).toEqualTypeOf<{ status: number }>();
   });
 });
+
+describe('HTPipe arity beyond 4 (P1-7)', () => {
+  it('composes 6 fragments where the 6th consumes context from fragments 1-5', () => {
+    const piped = HTPipe(
+      WithInputSlice('params', (p: any) => ({ id: String(p.id) })),
+      WithInputSlice('body', (b: any) => ({ name: String(b.name) })),
+      { preAuthorize: () => ({ role: 'admin' as const }) },
+      {
+        loadResources: (ctx: { inputs: { params: { id: string } } }) => ({
+          doc: { id: ctx.inputs.params.id, ownerId: 'o1' },
+        }),
+      },
+      {
+        finalAuthorize: (ctx: {
+          role: 'admin';
+          doc: { id: string; ownerId: string };
+        }) => ({ canWrite: ctx.role === 'admin' }),
+      },
+      {
+        execute: (ctx: {
+          inputs: { body: { name: string } };
+          doc: { id: string; ownerId: string };
+          canWrite: boolean;
+        }) => ({ saved: ctx.canWrite, name: ctx.inputs.body.name }),
+        redactResponse: (u: { saved: boolean; name: string }) => u,
+        responseMeta: { status: 201 },
+      }
+    );
+    expectTypeOf(piped.responseMeta).toEqualTypeOf<{ status: number }>();
+    type ExecOut = Awaited<ReturnType<(typeof piped)['execute']>>;
+    expectTypeOf<ExecOut>().toEqualTypeOf<{ saved: boolean; name: string }>();
+  });
+
+  it('composes 8 fragments', () => {
+    const noop = { preAuthorize: () => true };
+    const piped = HTPipe(
+      noop,
+      noop,
+      noop,
+      noop,
+      noop,
+      noop,
+      noop,
+      { execute: () => ({ ok: true }) }
+    );
+    expectTypeOf(piped.preAuthorize).toBeFunction();
+    expectTypeOf(piped.execute).toBeFunction();
+  });
+});

--- a/test/composition.test-d.ts
+++ b/test/composition.test-d.ts
@@ -101,16 +101,9 @@ describe('HTPipe arity beyond 4 (P1-7)', () => {
 
   it('composes 8 fragments', () => {
     const noop = { preAuthorize: () => true };
-    const piped = HTPipe(
-      noop,
-      noop,
-      noop,
-      noop,
-      noop,
-      noop,
-      noop,
-      { execute: () => ({ ok: true }) }
-    );
+    const piped = HTPipe(noop, noop, noop, noop, noop, noop, noop, {
+      execute: () => ({ ok: true }),
+    });
     expectTypeOf(piped.preAuthorize).toBeFunction();
     expectTypeOf(piped.execute).toBeFunction();
   });

--- a/test/composition.test-d.ts
+++ b/test/composition.test-d.ts
@@ -108,3 +108,35 @@ describe('HTPipe arity beyond 4 (P1-7)', () => {
     expectTypeOf(piped.execute).toBeFunction();
   });
 });
+
+describe('redactResponse context deps-met (P2-11)', () => {
+  const baseStages = {
+    sanitizeInputs: (i: any) => i,
+    preAuthorize: () => true,
+    execute: () => ({ rows: [] as { name: string; email: string }[] }),
+  };
+
+  it('a two-param redactor whose ctx key IS contributed compiles', () => {
+    const handler = toNextHandler({
+      ...baseStages,
+      finalAuthorize: () => ({ canSeeEmails: true }),
+      redactResponse: (
+        unsafe: { rows: { name: string; email: string }[] },
+        ctx: { canSeeEmails: boolean }
+      ) => (ctx.canSeeEmails ? unsafe.rows : []),
+    });
+    expectTypeOf(handler).toBeFunction();
+  });
+
+  it('a two-param redactor requiring an un-contributed ctx key fails deps-met', () => {
+    // @ts-expect-error - nothing contributes `canSeeEmails` to the context
+    toNextHandler({
+      ...baseStages,
+      finalAuthorize: () => true,
+      redactResponse: (
+        unsafe: { rows: { name: string; email: string }[] },
+        ctx: { canSeeEmails: boolean }
+      ) => (ctx.canSeeEmails ? unsafe.rows : []),
+    });
+  });
+});

--- a/test/composition.test-d.ts
+++ b/test/composition.test-d.ts
@@ -1,0 +1,51 @@
+// Type-level tests for HTPipe composition (Finding P0-1 / P1-7).
+// Run via `vitest --typecheck` (enabled in vitest.config.ts).
+import { describe, expectTypeOf, it } from 'vitest';
+import { HTPipe, WithInputSlice } from '../src/index.js';
+import { toNextHandler } from '../src/next.js';
+
+describe('HTPipe sanitizeInputs composition (P0-1)', () => {
+  it('keeps both slices visible after piping two WithInputSlice fragments', () => {
+    const piped = HTPipe(
+      WithInputSlice('params', (p: any) => ({ id: String(p.id) })),
+      WithInputSlice('body', (b: any) => ({ name: String(b.name) }))
+    );
+    type SanitizedOut = ReturnType<(typeof piped)['sanitizeInputs']>;
+    expectTypeOf<SanitizedOut['params']>().toEqualTypeOf<{ id: string }>();
+    expectTypeOf<SanitizedOut['body']>().toEqualTypeOf<{ name: string }>();
+  });
+
+  it('a later stage can consume the LEFT slice through an adapter (README shape)', () => {
+    // This is the canonical multi-slice handler from the README. Before the
+    // P0-1 fix, the composed sanitizeInputs return type dropped `params`
+    // (keeping only the right fragment's return), so this failed to typecheck.
+    const handler = toNextHandler(
+      HTPipe(
+        WithInputSlice('params', (p: any) => ({ id: String(p.id) })),
+        WithInputSlice('body', (b: any) => ({ name: String(b.name) })),
+        {
+          preAuthorize: () => true,
+          loadResources: async (ctx: {
+            inputs: { params: { id: string } };
+          }) => ({
+            thing: { ownerId: 'x' } as { ownerId: string } | null,
+          }),
+          finalAuthorize: (ctx: { thing: { ownerId: string } | null }) =>
+            !!ctx.thing,
+          execute: (ctx: { thing: { ownerId: string } | null }) => ctx.thing,
+          redactResponse: (t: unknown) => t,
+        }
+      )
+    );
+    expectTypeOf(handler).toBeFunction();
+  });
+
+  it('full-replace sanitizer on the right does not inherit left keys', () => {
+    const piped = HTPipe(
+      WithInputSlice('params', (p: any) => ({ id: String(p.id) })),
+      { sanitizeInputs: (_all: any) => ({ replaced: true as const }) }
+    );
+    type SanitizedOut = ReturnType<(typeof piped)['sanitizeInputs']>;
+    expectTypeOf<SanitizedOut>().toEqualTypeOf<{ replaced: true }>();
+  });
+});

--- a/test/composition.test-d.ts
+++ b/test/composition.test-d.ts
@@ -49,3 +49,20 @@ describe('HTPipe sanitizeInputs composition (P0-1)', () => {
     expectTypeOf<SanitizedOut>().toEqualTypeOf<{ replaced: true }>();
   });
 });
+
+describe('HTPipe non-stage key passthrough (P0-2)', () => {
+  it('the piped type keeps responseMeta with right-wins semantics', () => {
+    const piped = HTPipe(
+      { preAuthorize: () => true, responseMeta: { status: 200 } },
+      {
+        sanitizeInputs: (i: any) => i,
+        preAuthorize: () => true,
+        finalAuthorize: () => true,
+        execute: () => ({}),
+        redactResponse: (u: any) => u,
+        responseMeta: { status: 201 },
+      }
+    );
+    expectTypeOf(piped.responseMeta).toEqualTypeOf<{ status: number }>();
+  });
+});

--- a/test/deps-met.test-d.ts
+++ b/test/deps-met.test-d.ts
@@ -3,7 +3,10 @@
 // collapse handler inference to `never`, and genuinely-unmet dependencies
 // must fail with the branded HipDepNotMet type (naming stage + key) rather
 // than an unreadable `never`.
+import mongoose from 'mongoose';
 import { describe, expectTypeOf, it } from 'vitest';
+import { HTPipe } from '../src/index.js';
+import { htMongooseFactory } from '../src/mongoose.js';
 import { toNextHandler } from '../src/next.js';
 
 const requiredStages = {
@@ -60,6 +63,49 @@ describe('deps-met tolerance (P1-8)', () => {
     toNextHandler({
       ...requiredStages,
       finalAuthorize: (ctx: { doc: { id: string } }) => !!ctx.doc,
+    });
+  });
+});
+
+describe('scoped list endpoints require a queryScope provider (P2-10)', () => {
+  const listModel = {
+    find: (_filter: any) => ({ exec: async () => [] as any[] }),
+  };
+
+  it('compiles when a fragment contributes queryScope', () => {
+    const handler = toNextHandler(
+      HTPipe(
+        {
+          loadResources: (ctx: { ambient: { tenantIds: string[] } }) => ({
+            queryScope: { tenant: { $in: ctx.ambient.tenantIds } } as Record<
+              string,
+              unknown
+            >,
+          }),
+        },
+        {
+          extractAmbient: (raw: any) => ({
+            tenantIds: (raw.tenantIds || []) as string[],
+          }),
+          sanitizeInputs: (i: any) => i,
+          preAuthorize: () => true,
+          finalAuthorize: () => true,
+          ...htMongooseFactory(mongoose).findScoped(listModel),
+          redactResponse: (u: any) => u,
+        }
+      )
+    );
+    expectTypeOf(handler).toBeFunction();
+  });
+
+  it('using findScoped without any scope-providing fragment fails to compile', () => {
+    // @ts-expect-error - nothing contributes `queryScope`
+    toNextHandler({
+      sanitizeInputs: (i: any) => i,
+      preAuthorize: () => true,
+      finalAuthorize: () => true,
+      ...htMongooseFactory(mongoose).findScoped(listModel),
+      redactResponse: (u: any) => u,
     });
   });
 });

--- a/test/deps-met.test-d.ts
+++ b/test/deps-met.test-d.ts
@@ -1,0 +1,65 @@
+// Type-level tests for the deps-met machinery's tolerance and diagnostics
+// (Finding P1-8): `any`-typed context keys and union stage returns must not
+// collapse handler inference to `never`, and genuinely-unmet dependencies
+// must fail with the branded HipDepNotMet type (naming stage + key) rather
+// than an unreadable `never`.
+import { describe, expectTypeOf, it } from 'vitest';
+import { toNextHandler } from '../src/next.js';
+
+const requiredStages = {
+  sanitizeInputs: (i: any) => i,
+  preAuthorize: () => true,
+  execute: () => ({ done: true }),
+  redactResponse: (u: any) => u,
+};
+
+describe('deps-met tolerance (P1-8)', () => {
+  it('a context key declared as `any` does not collapse inference', () => {
+    // Repro 1 from the downstream port: `transferNumber: any` used to make
+    // TConf resolve to never ("not assignable to parameter of type 'never'").
+    const handler = toNextHandler({
+      ...requiredStages,
+      loadResources: () => ({ transferNumber: '555' }),
+      finalAuthorize: (ctx: { transferNumber: any }) => !!ctx.transferNumber,
+    });
+    expectTypeOf(handler).toBeFunction();
+  });
+
+  it('a union loadResources return (conditional shape) is accepted when a member provides the key', () => {
+    // Repro 2: `if (!doc) return {}; return { doc, extra }` — a union return.
+    const handler = toNextHandler({
+      ...requiredStages,
+      loadResources: () => {
+        if (Math.random() > 0.5) {
+          return {};
+        }
+        return { doc: { id: 'x' }, extra: 1 };
+      },
+      finalAuthorize: (ctx: { doc: { id: string } }) => !!ctx.doc,
+    });
+    expectTypeOf(handler).toBeFunction();
+  });
+
+  it('preAuthorize returns with a false branch still count as providers', () => {
+    const handler = toNextHandler({
+      ...requiredStages,
+      preAuthorize: () => {
+        if (Math.random() > 0.5) {
+          return false as const;
+        }
+        return { role: 'admin' };
+      },
+      finalAuthorize: (ctx: { role: string }) => ctx.role === 'admin',
+    });
+    expectTypeOf(handler).toBeFunction();
+  });
+
+  it('a genuinely-unmet dependency is still a compile error (branded, not never)', () => {
+    // @ts-expect-error - nothing contributes `doc`; the error mentions
+    // HipDepNotMet<'finalAuthorize', 'doc'> instead of `never`.
+    toNextHandler({
+      ...requiredStages,
+      finalAuthorize: (ctx: { doc: { id: string } }) => !!ctx.doc,
+    });
+  });
+});

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
 import {
   HipBadInputs,
   HipConflict,
   HipError,
+  hipErrorToBody,
   hipErrorToStatus,
   HipForbidden,
   HipInternal,
@@ -57,5 +59,50 @@ describe('HipRedirect', () => {
     expect(r.redirectUrl).toBe('/dashboard');
     expect(r.redirectCode).toBe(302);
     expect(new HipRedirect('/x', 307).redirectCode).toBe(307);
+  });
+});
+
+describe('hipErrorToBody (Finding P0-3)', () => {
+  it('projects a ZodError detail to issues with paths+messages and no input values', () => {
+    const schema = z.object({ name: z.string(), age: z.number() });
+    const parsed = schema.safeParse({ name: 42, age: 'secret-value' });
+    expect(parsed.success).toBe(false);
+    const body = hipErrorToBody(
+      new HipBadInputs(
+        'body not valid',
+        (parsed as { error: z.ZodError }).error
+      )
+    );
+    expect(body.error).toBe('body not valid');
+    expect(body.issues!.length).toBeGreaterThan(0);
+    for (const issue of body.issues!) {
+      expect(Array.isArray(issue.path)).toBe(true);
+      expect(typeof issue.message).toBe('string');
+      expect(Object.keys(issue).sort()).toEqual(['message', 'path']);
+    }
+    expect(JSON.stringify(body)).not.toContain('secret-value');
+    expect(body.detail).toBeUndefined();
+  });
+
+  it('exposes structured detail only with the explicit expose opt-in', () => {
+    const payload = { blockedBy: ['x'], blockingItems: ['y'] };
+    const optedIn = hipErrorToBody(
+      new HipConflict('blocked', payload, { expose: true })
+    );
+    expect(optedIn.detail).toEqual(payload);
+    const notOptedIn = hipErrorToBody(new HipConflict('blocked', payload));
+    expect(notOptedIn).toEqual({ error: 'blocked' });
+  });
+
+  it('HipInternal never exposes detail or issues, even when opted in', () => {
+    const zodError = z.object({ a: z.string() }).safeParse({ a: 1 });
+    const body = hipErrorToBody(
+      new HipInternal(
+        'Internal server error',
+        (zodError as { error?: z.ZodError }).error,
+        { expose: true }
+      )
+    );
+    expect(body).toEqual({ error: 'Internal server error' });
   });
 });

--- a/test/express-adapter.test.ts
+++ b/test/express-adapter.test.ts
@@ -72,7 +72,7 @@ describe('toExpressHandler', () => {
     expect(res.body).toEqual({ echoed: { id: 'abc', n: 7 } });
   });
 
-  it('forwards a denied authorization to next as an error', async () => {
+  it('responds directly to a denied authorization with a 403 error body', async () => {
     const handler = toExpressHandler({
       sanitizeInputs: (i: any) => i,
       preAuthorize: () => {
@@ -85,8 +85,28 @@ describe('toExpressHandler', () => {
     const next = vi.fn();
     const res = fakeRes();
     await handler(rawReq() as any, res, next as any);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: 'nope' });
+  });
+
+  it('delegateErrors forwards the HipError itself to next()', async () => {
+    const handler = toExpressHandler(
+      {
+        sanitizeInputs: (i: any) => i,
+        preAuthorize: () => {
+          throw new HipForbidden('nope');
+        },
+        finalAuthorize: () => true,
+        execute: () => ({}),
+        redactResponse: (u: any) => u,
+      },
+      { delegateErrors: true }
+    );
+    const next = vi.fn();
+    await handler(rawReq() as any, fakeRes(), next as any);
     expect(next).toHaveBeenCalledTimes(1);
-    expect(next.mock.calls[0][0]).toBeDefined();
+    expect(next.mock.calls[0][0]).toBeInstanceOf(HipForbidden);
   });
 
   it('issues a redirect when a HipRedirect is thrown', async () => {
@@ -115,7 +135,7 @@ describe('express adapter options (Findings P1-5, P1-6)', () => {
     redactResponse: (u: any) => u,
   };
 
-  it('onError fires with the converted error before next() and a throwing hook is harmless', async () => {
+  it('onError fires with the converted error and a throwing hook is harmless', async () => {
     const seen: unknown[] = [];
     const boom = new Error('db down');
     const handler = toExpressHandler(
@@ -132,9 +152,10 @@ describe('express adapter options (Findings P1-5, P1-6)', () => {
         },
       }
     );
-    const next = vi.fn();
-    await handler(rawReq() as any, fakeRes(), next);
-    expect(next).toHaveBeenCalledTimes(1);
+    const res = fakeRes();
+    await handler(rawReq() as any, res, vi.fn());
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: 'Internal server error' });
     expect((seen[0] as Error).cause).toBe(boom);
   });
 

--- a/test/express-adapter.test.ts
+++ b/test/express-adapter.test.ts
@@ -105,3 +105,56 @@ describe('toExpressHandler', () => {
     expect(res.redirectCode).toBe(302);
   });
 });
+
+describe('express adapter options (Findings P1-5, P1-6)', () => {
+  const okStages = {
+    sanitizeInputs: (i: any) => i,
+    preAuthorize: () => true,
+    finalAuthorize: () => true,
+    execute: () => ({ ok: true }),
+    redactResponse: (u: any) => u,
+  };
+
+  it('onError fires with the converted error before next() and a throwing hook is harmless', async () => {
+    const seen: unknown[] = [];
+    const boom = new Error('db down');
+    const handler = toExpressHandler(
+      {
+        ...okStages,
+        loadResources: () => {
+          throw boom;
+        },
+      },
+      {
+        onError: (e) => {
+          seen.push(e);
+          throw new Error('broken logger');
+        },
+      }
+    );
+    const next = vi.fn();
+    await handler(rawReq() as any, fakeRes(), next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect((seen[0] as Error).cause).toBe(boom);
+  });
+
+  it('afterResponse fires on res finish with the final context', async () => {
+    let ctx: any;
+    const listeners: Record<string, () => void> = {};
+    const res = fakeRes();
+    res.on = (event: string, cb: () => void) => {
+      listeners[event] = cb;
+    };
+    const handler = toExpressHandler(okStages, {
+      afterResponse: (c) => {
+        ctx = c;
+      },
+    });
+    await handler(rawReq({ body: { x: 1 } }) as any, res, vi.fn());
+    expect(ctx).toBeUndefined();
+    listeners.finish();
+    await new Promise((r) => setTimeout(r, 5));
+    expect(ctx.response).toEqual({ ok: true });
+    expect(ctx.inputs.body).toEqual({ x: 1 });
+  });
+});

--- a/test/fastify-adapter.test.ts
+++ b/test/fastify-adapter.test.ts
@@ -100,3 +100,50 @@ describe('toFastifyHandler', () => {
     expect(reply.redirectedTo).toBe('/home');
   });
 });
+
+describe('fastify adapter options (Findings P1-5, P1-6)', () => {
+  const okStages = {
+    sanitizeInputs: (i: any) => i,
+    preAuthorize: () => true,
+    finalAuthorize: () => true,
+    execute: () => ({ ok: true }),
+    redactResponse: (u: any) => u,
+  };
+
+  it('onError fires on the 500 path and a throwing hook is harmless', async () => {
+    const seen: unknown[] = [];
+    const boom = new Error('db down');
+    const handler = toFastifyHandler(
+      {
+        ...okStages,
+        execute: () => {
+          throw boom;
+        },
+      },
+      {
+        onError: (e) => {
+          seen.push(e);
+          throw new Error('broken logger');
+        },
+      }
+    );
+    const reply = fakeReply();
+    await handler(fakeReq() as any, reply);
+    expect(reply.statusCode).toBe(500);
+    expect((seen[0] as Error).cause).toBe(boom);
+  });
+
+  it('afterResponse receives the final context after the reply is sent', async () => {
+    let ctx: any;
+    const handler = toFastifyHandler(okStages, {
+      afterResponse: (c) => {
+        ctx = c;
+      },
+    });
+    const reply = fakeReply();
+    await handler(fakeReq({ body: { x: 1 } }) as any, reply);
+    await new Promise((r) => setImmediate(r));
+    expect(ctx.response).toEqual({ ok: true });
+    expect(ctx.inputs.body).toEqual({ x: 1 });
+  });
+});

--- a/test/hono-adapter.test.ts
+++ b/test/hono-adapter.test.ts
@@ -7,6 +7,7 @@ function fakeContext(opts: {
   params?: Record<string, string>;
   query?: Record<string, string>;
   body?: any;
+  bodyText?: string;
   headers?: Record<string, string>;
 }): any {
   const calls: any = {};
@@ -17,6 +18,12 @@ function fakeContext(opts: {
       param: () => opts.params || {},
       query: () => opts.query || {},
       header: () => opts.headers || {},
+      text: async () => {
+        if (opts.bodyText !== undefined) {
+          return opts.bodyText;
+        }
+        return opts.body === undefined ? '' : JSON.stringify(opts.body);
+      },
       json: async () => {
         if (opts.body === undefined) {
           throw new Error('no body');
@@ -114,5 +121,67 @@ describe('toHonoHandler', () => {
     const c = fakeContext({ body: {} });
     await handler(c);
     expect(c.calls.redirect).toEqual({ url: '/dashboard', code: 301 });
+  });
+});
+
+describe('hono adapter options (Findings P1-5, P2-12.2)', () => {
+  const okStages = {
+    sanitizeInputs: (i: any) => i,
+    preAuthorize: () => true,
+    finalAuthorize: () => true,
+    execute: () => ({ ok: true }),
+    redactResponse: (u: any) => u,
+  };
+
+  it('a malformed JSON body responds 422 by default', async () => {
+    const handler = toHonoHandler(okStages, {});
+    const c = fakeContext({ bodyText: '{not json' });
+    await handler(c);
+    expect(c.calls.json.status).toBe(422);
+    expect(c.calls.json.body.error).toBe('Malformed JSON body');
+  });
+
+  it('allowMalformedBody restores the old coerce-to-{} behavior', async () => {
+    const handler = toHonoHandler(okStages, { allowMalformedBody: true });
+    const c = fakeContext({ bodyText: '{not json' });
+    await handler(c);
+    expect(c.calls.json.status).toBe(200);
+  });
+
+  it('onError fires with the converted error and a throwing hook is harmless', async () => {
+    const seen: unknown[] = [];
+    const boom = new Error('db down');
+    const handler = toHonoHandler(
+      {
+        ...okStages,
+        execute: () => {
+          throw boom;
+        },
+      },
+      {
+        onError: (e) => {
+          seen.push(e);
+          throw new Error('broken logger');
+        },
+      }
+    );
+    const c = fakeContext({ body: {} });
+    await handler(c);
+    expect(c.calls.json.status).toBe(500);
+    expect((seen[0] as Error).cause).toBe(boom);
+  });
+
+  it('afterResponse receives the final context', async () => {
+    let ctx: any;
+    const handler = toHonoHandler(okStages, {
+      afterResponse: (c2) => {
+        ctx = c2;
+      },
+    });
+    const c = fakeContext({ body: { x: 1 } });
+    await handler(c);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(ctx.response).toEqual({ ok: true });
+    expect(ctx.inputs.body).toEqual({ x: 1 });
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -665,3 +665,66 @@ describe('HipThrusTS', () => {
     });
   });
 });
+
+describe('HTPipe non-stage key passthrough (Finding P0-2)', () => {
+  const requiredStages = {
+    sanitizeInputs: (i: any) => i,
+    preAuthorize: () => true,
+    finalAuthorize: () => true,
+    execute: () => ({ made: true }),
+    redactResponse: (u: any) => u,
+  };
+
+  it('carries responseMeta through HTPipe', () => {
+    const piped = HTPipe(
+      { preAuthorize: () => true },
+      { ...requiredStages, responseMeta: { status: 201 } }
+    );
+    expect((piped as any).responseMeta).toEqual({ status: 201 });
+  });
+
+  it('right fragment responseMeta wins over the left one', () => {
+    const piped = HTPipe(
+      { preAuthorize: () => true, responseMeta: { status: 200 } },
+      { ...requiredStages, responseMeta: { status: 201 } }
+    );
+    expect((piped as any).responseMeta).toEqual({ status: 201 });
+  });
+
+  it('passes non-stage keys through multi-fragment pipes and single-fragment pipes', () => {
+    const single = HTPipe({ ...requiredStages, responseMeta: { status: 202 } });
+    expect((single as any).responseMeta).toEqual({ status: 202 });
+    const triple = HTPipe(
+      { preAuthorize: () => true, responseMeta: { status: 200 } },
+      { loadResources: () => ({}) },
+      { ...requiredStages, responseMeta: { status: 201 } }
+    );
+    expect((triple as any).responseMeta).toEqual({ status: 201 });
+  });
+
+  it('a piped responseMeta reaches the wire through an HTTP adapter', async () => {
+    const handler = toExpressHandler(
+      HTPipe(
+        { preAuthorize: () => true },
+        { ...requiredStages, responseMeta: { status: 201 } }
+      ) as any
+    );
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json() {
+        return this;
+      },
+      setHeader() {},
+    };
+    await handler(
+      { params: {}, query: {}, body: {}, headers: {} } as any,
+      res,
+      (() => undefined) as any
+    );
+    expect(res.statusCode).toBe(201);
+  });
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { HTPipe, WithInputSlice } from '../src';
+import { HTPipe, SanitizeInputsSlices, UNSAFE_SLICES } from '../src';
 import { executeHipthrustable, withDefaultImplementations } from '../src/core';
 import { HipForbidden } from '../src/errors';
 import { toExpressHandler } from '../src/express';
@@ -290,31 +290,35 @@ describe('HipThrusTS', () => {
       });
     });
 
-    describe('WithInputSlice', () => {
-      it('writes to sanitizeInputs under named slice and preserves others', () => {
-        const params = WithInputSlice('params', (p: { id: string }) => ({
-          id: p.id.trim(),
-        }));
+    describe('SanitizeInputsSlices', () => {
+      it('names only sanitized slices; the raw rest rides the UNSAFE_SLICES channel', () => {
+        const params = SanitizeInputsSlices({
+          params: (p: { id: string }) => ({ id: p.id.trim() }),
+        });
         const out = params.sanitizeInputs({
           params: { id: '  abc  ' },
           body: { keep: true },
           query: {},
           headers: {},
         });
-        expect(out).toEqual({
-          params: { id: 'abc' },
+        expect(out.params).toEqual({ id: 'abc' });
+        expect(Object.keys(out)).toEqual(['params']);
+        expect((out as any)[UNSAFE_SLICES]).toEqual({
+          params: { id: '  abc  ' },
           body: { keep: true },
           query: {},
           headers: {},
         });
       });
 
-      it('composes with HTPipe so multiple slices coexist', () => {
+      it('composes with HTPipe so multiple slices coexist (unsanitized ones stay raw-channel-only)', () => {
         const both = HTPipe(
-          WithInputSlice('params', (p: { id: string }) => ({ id: p.id })),
-          WithInputSlice('body', (b: { name: string }) => ({
-            name: b.name.toUpperCase(),
-          }))
+          SanitizeInputsSlices({
+            params: (p: { id: string }) => ({ id: p.id }),
+          }),
+          SanitizeInputsSlices({
+            body: (b: { name: string }) => ({ name: b.name.toUpperCase() }),
+          })
         );
         const out = both.sanitizeInputs({
           params: { id: '42' },
@@ -322,12 +326,17 @@ describe('HipThrusTS', () => {
           query: { ignored: true },
           headers: {},
         });
-        expect(out).toEqual({
-          params: { id: '42' },
-          body: { name: 'FOO' },
-          query: { ignored: true },
-          headers: {},
-        });
+        expect(out.params).toEqual({ id: '42' });
+        expect(out.body).toEqual({ name: 'FOO' });
+        expect(Object.keys(out).sort()).toEqual(['body', 'params']);
+        expect((out as any)[UNSAFE_SLICES].query).toEqual({ ignored: true });
+      });
+
+      it('an explicit no-op slice is the way to pass raw data through', () => {
+        const frag = SanitizeInputsSlices({ query: (q: unknown) => q });
+        const out = frag.sanitizeInputs({ query: { raw: 1 }, body: { x: 2 } });
+        expect(out.query).toEqual({ raw: 1 });
+        expect(Object.keys(out)).toEqual(['query']);
       });
     });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,3 @@
-import Boom from '@hapi/boom';
 import { describe, expect, it } from 'vitest';
 
 import { HTPipe, WithInputSlice } from '../src';
@@ -584,7 +583,7 @@ describe('HipThrusTS', () => {
         expect(resUpdated.statusCode).toBe(200);
       });
 
-      it('translates a denied authorization to a Boom 403 via next', async () => {
+      it('translates a denied authorization to a direct 403 response', async () => {
         const handler = toExpressHandler({
           sanitizeInputs: (i: any) => i,
           preAuthorize: () => false,
@@ -592,14 +591,10 @@ describe('HipThrusTS', () => {
           execute: () => ({}),
           redactResponse: (u: any) => u,
         });
-        let nextErr: any;
         const res = fakeRes();
-        await handler(rawReq as any, res, ((e: any) => {
-          nextErr = e;
-        }) as any);
-        expect(nextErr).toBeDefined();
-        expect(Boom.isBoom(nextErr)).toBe(true);
-        expect(nextErr.output.statusCode).toBe(403);
+        await handler(rawReq as any, res, (() => undefined) as any);
+        expect(res.statusCode).toBe(403);
+        expect(res.body.error).toBeDefined();
       });
     });
 

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -105,8 +105,10 @@ describe('executeHipthrustable lifecycle', () => {
 
   // Regression test for the transformThrowPossiblyAsync sync-throw bug: an
   // async-capable stage (loadResources) that throws *synchronously* must still
-  // be transformed to the stage's semantic HipError, not leak the raw error.
-  it('transforms a SYNCHRONOUS throw from loadResources to HipNotFound', async () => {
+  // be transformed to a HipError, not leak the raw error. (Since Finding P0-4
+  // the transformed error is HipInternal — 404 is reserved for a deliberate
+  // HipNotFound throw.)
+  it('transforms a SYNCHRONOUS throw from loadResources to HipInternal', async () => {
     const handler = buildHandler({
       loadResources: () => {
         throw new Error('sync boom from an async-capable stage');
@@ -119,17 +121,103 @@ describe('executeHipthrustable lifecycle', () => {
       caught = e;
     }
     expect(isHipError(caught)).toBe(true);
-    expect(caught).toBeInstanceOf(HipNotFound);
+    expect(caught).toBeInstanceOf(HipInternal);
   });
 
-  it('still transforms an ASYNCHRONOUS rejection from loadResources to HipNotFound', async () => {
+  it('still transforms an ASYNCHRONOUS rejection from loadResources to HipInternal', async () => {
     const handler = buildHandler({
       loadResources: async () => {
         throw new Error('async boom');
       },
     });
     await expect(executeHipthrustable(handler, {})).rejects.toThrow(
-      HipNotFound
+      HipInternal
     );
+  });
+});
+
+describe('unknown-error routing (Finding P0-4)', () => {
+  const base = {
+    extractAmbient: () => ({}),
+    extractInputs: (raw: any) => raw,
+    sanitizeInputs: (i: any) => i,
+    preAuthorize: () => true,
+    loadResources: () => ({}),
+    finalAuthorize: () => true,
+    execute: () => ({ ok: true }),
+    redactResponse: (u: any) => u,
+  };
+
+  async function run(overrides: Record<string, any>) {
+    try {
+      await executeHipthrustable({ ...base, ...overrides } as any, {});
+      return undefined;
+    } catch (e) {
+      return e;
+    }
+  }
+
+  it('an unknown throw in loadResources becomes HipInternal with the original as cause', async () => {
+    const dbDown = new Error('db down');
+    const caught = await run({
+      loadResources: () => {
+        throw dbDown;
+      },
+    });
+    expect(caught).toBeInstanceOf(HipInternal);
+    expect((caught as HipInternal).message).toBe('Internal server error');
+    expect((caught as HipInternal).cause).toBe(dbDown);
+  });
+
+  it('an unknown throw in preAuthorize/finalAuthorize becomes HipInternal, not 403', async () => {
+    for (const stage of ['preAuthorize', 'finalAuthorize']) {
+      const boom = new Error('db down');
+      const caught = await run({
+        [stage]: () => {
+          throw boom;
+        },
+      });
+      expect(caught).toBeInstanceOf(HipInternal);
+      expect((caught as HipInternal).cause).toBe(boom);
+    }
+  });
+
+  it('a deliberate HipNotFound from loadResources still surfaces as-is', async () => {
+    const caught = await run({
+      loadResources: () => {
+        throw new HipNotFound('Resource not found');
+      },
+    });
+    expect(caught).toBeInstanceOf(HipNotFound);
+  });
+
+  it('unknown throws during input stages stay HipBadInputs and chain the cause', async () => {
+    const zodish = new Error('invalid');
+    const caught = await run({
+      sanitizeInputs: () => {
+        throw zodish;
+      },
+    });
+    expect(caught).toBeInstanceOf(HipBadInputs);
+    expect((caught as HipBadInputs).cause).toBe(zodish);
+  });
+
+  it('an unknown throw in execute uses the standard scrub message and chains the cause', async () => {
+    const boom = new Error('whoops');
+    const caught = await run({
+      execute: () => {
+        throw boom;
+      },
+    });
+    expect(caught).toBeInstanceOf(HipInternal);
+    expect((caught as HipInternal).message).toBe('Internal server error');
+    expect((caught as HipInternal).cause).toBe(boom);
+  });
+
+  it('returning false from the authorize stages still yields HipForbidden', async () => {
+    const pre = await run({ preAuthorize: () => false });
+    expect(pre).toBeInstanceOf(HipForbidden);
+    const fin = await run({ finalAuthorize: () => false });
+    expect(fin).toBeInstanceOf(HipForbidden);
   });
 });

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { HTPipe } from '../src';
 import { executeHipthrustable, withDefaultImplementations } from '../src/core';
 import {
   HipBadInputs,
@@ -219,5 +220,57 @@ describe('unknown-error routing (Finding P0-4)', () => {
     expect(pre).toBeInstanceOf(HipForbidden);
     const fin = await run({ finalAuthorize: () => false });
     expect(fin).toBeInstanceOf(HipForbidden);
+  });
+});
+
+describe('redactResponse receives the final context (Finding P2-11)', () => {
+  it('a two-param redactor can branch on an authz flag from finalAuthorize', async () => {
+    const handler = withDefaultImplementations({
+      sanitizeInputs: (i: any) => i,
+      preAuthorize: () => true,
+      finalAuthorize: () => ({ canSeeEmails: false }),
+      execute: () => ({ rows: [{ name: 'a', email: 'a@x.com' }] }),
+      redactResponse: (
+        unsafe: { rows: { name: string; email: string }[] },
+        ctx: { canSeeEmails: boolean }
+      ) =>
+        ctx.canSeeEmails
+          ? unsafe.rows
+          : unsafe.rows.map(({ name }) => ({ name })),
+    } as any);
+    const { response } = await executeHipthrustable(handler as any, {});
+    expect(response).toEqual([{ name: 'a' }]);
+  });
+
+  it('one-param redactors keep working unchanged', async () => {
+    const handler = withDefaultImplementations({
+      sanitizeInputs: (i: any) => i,
+      preAuthorize: () => true,
+      finalAuthorize: () => true,
+      execute: () => ({ a: 1, secret: 's' }),
+      redactResponse: (u: { a: number; secret: string }) => ({ a: u.a }),
+    } as any);
+    const { response } = await executeHipthrustable(handler as any, {});
+    expect(response).toEqual({ a: 1 });
+  });
+
+  it('piped redactors both receive the context', async () => {
+    const seen: any[] = [];
+    const piped = HTPipe(
+      {
+        redactResponse: (u: any, ctx: any) => {
+          seen.push(ctx.role);
+          return u;
+        },
+      },
+      {
+        redactResponse: (u: any, ctx: any) => {
+          seen.push(ctx.role);
+          return u;
+        },
+      }
+    );
+    (piped as any).redactResponse({ x: 1 }, { role: 'admin' });
+    expect(seen).toEqual(['admin', 'admin']);
   });
 });

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { HTPipe } from '../src';
+import { HTPipe, SanitizeInputsSlices } from '../src';
 import { executeHipthrustable, withDefaultImplementations } from '../src/core';
 import {
   HipBadInputs,
@@ -272,5 +272,37 @@ describe('redactResponse receives the final context (Finding P2-11)', () => {
     );
     (piped as any).redactResponse({ x: 1 }, { role: 'admin' });
     expect(seen).toEqual(['admin', 'admin']);
+  });
+});
+
+describe('strict sanitization guarantee (UNSAFE_SLICES stripped by core)', () => {
+  it('unsanitized slices never reach stages after sanitizeInputs', async () => {
+    const handler = withDefaultImplementations({
+      ...SanitizeInputsSlices({ params: (p: any) => ({ id: String(p.id) }) }),
+      preAuthorize: () => true,
+      finalAuthorize: () => true,
+      execute: (ctx: any) => ctx.inputs,
+      redactResponse: (u: any) => u,
+    } as any);
+    const { response } = await executeHipthrustable(handler, {
+      params: { id: 7 },
+      body: { sneaky: true },
+      query: { alsoSneaky: 1 },
+      headers: {},
+    });
+    expect(response).toEqual({ params: { id: '7' } });
+    expect(Object.getOwnPropertySymbols(response)).toEqual([]);
+  });
+
+  it('a full-replace sanitizer is untouched (tRPC-style single input)', async () => {
+    const handler = withDefaultImplementations({
+      sanitizeInputs: (i: any) => ({ n: Number(i.n) }),
+      preAuthorize: () => true,
+      finalAuthorize: () => true,
+      execute: (ctx: any) => ctx.inputs,
+      redactResponse: (u: any) => u,
+    } as any);
+    const { response } = await executeHipthrustable(handler, { n: '5' });
+    expect(response).toEqual({ n: 5 });
   });
 });

--- a/test/mongoose.test.ts
+++ b/test/mongoose.test.ts
@@ -82,29 +82,27 @@ describe('SanitizeInputsWithMongoose', () => {
   });
 });
 
-describe('SanitizeInputsSliceWithMongoose', () => {
+describe('SanitizeInputsSlicesWithMongoose', () => {
   const factory = ht.documentFactoryFromForRequest({
     id: { type: String, required: true },
   });
 
-  it('sanitizes the named slice and passes the rest through', () => {
-    const { sanitizeInputs } = ht.SanitizeInputsSliceWithMongoose(
-      'params',
-      factory
-    );
+  it('sanitizes the named slice; unnamed slices are not named keys', () => {
+    const { sanitizeInputs } = ht.SanitizeInputsSlicesWithMongoose({
+      params: factory,
+    });
     const result = sanitizeInputs({
       params: { id: '7' },
       body: { untouched: true },
     });
     expect(result.params).toEqual({ id: '7' });
-    expect(result.body).toEqual({ untouched: true });
+    expect(Object.keys(result)).toEqual(['params']);
   });
 
   it('throws HipBadInputs naming the slice when invalid', () => {
-    const { sanitizeInputs } = ht.SanitizeInputsSliceWithMongoose(
-      'params',
-      factory
-    );
+    const { sanitizeInputs } = ht.SanitizeInputsSlicesWithMongoose({
+      params: factory,
+    });
     expect(() => sanitizeInputs({ params: {} })).toThrow('params not valid');
   });
 });
@@ -216,16 +214,26 @@ describe('findScoped / loadScopedTo (Finding P2-10)', () => {
     },
   };
 
-  it('findScoped composes ctx.queryScope into the filter (two-tenant fixture)', async () => {
-    const { execute } = ht.findScoped(FakeModel);
-    const result = await execute({ queryScope: { tenant: { $in: ['a'] } } });
-    expect(result.map((r: any) => r.name)).toEqual(['a-one', 'a-two']);
+  it('findScoped loads scoped rows on the LOAD stage and its execute returns them', async () => {
+    const frag = ht.findScoped(FakeModel);
+    const loaded = await frag.loadResources({
+      queryScope: { tenant: { $in: ['a'] } },
+    });
+    expect(loaded.scopedDocs.map((r: any) => r.name)).toEqual([
+      'a-one',
+      'a-two',
+    ]);
+    expect(frag.execute({ ...loaded })).toBe(loaded.scopedDocs);
   });
 
-  it('findScoped merges an extra filter on top of the scope', async () => {
-    const { execute } = ht.findScoped(FakeModel, { name: 'a-two' });
-    const result = await execute({ queryScope: { tenant: { $in: ['a'] } } });
-    expect(result.map((r: any) => r.name)).toEqual(['a-two']);
+  it('findScoped merges an extra filter and honors a custom docs key', async () => {
+    const frag = ht.findScoped(FakeModel, { name: 'a-two' }, 'items');
+    const loaded = await frag.loadResources({
+      queryScope: { tenant: { $in: ['a'] } },
+    });
+    expect(frag.execute({ ...loaded }).map((r: any) => r.name)).toEqual([
+      'a-two',
+    ]);
   });
 
   it('loadScopedTo stores the scoped rows under the given key', async () => {

--- a/test/mongoose.test.ts
+++ b/test/mongoose.test.ts
@@ -194,3 +194,45 @@ describe('dtoSchemaObj', () => {
     });
   });
 });
+
+describe('findScoped / loadScopedTo (Finding P2-10)', () => {
+  const rows = [
+    { _id: '1', tenant: 'a', name: 'a-one' },
+    { _id: '2', tenant: 'a', name: 'a-two' },
+    { _id: '3', tenant: 'b', name: 'b-one' },
+  ];
+  const FakeModel = {
+    find(filter: Record<string, any>) {
+      return {
+        exec: async () =>
+          rows.filter((row) =>
+            Object.entries(filter).every(([k, v]) =>
+              v && typeof v === 'object' && Array.isArray(v.$in)
+                ? v.$in.includes((row as any)[k])
+                : (row as any)[k] === v
+            )
+          ),
+      };
+    },
+  };
+
+  it('findScoped composes ctx.queryScope into the filter (two-tenant fixture)', async () => {
+    const { execute } = ht.findScoped(FakeModel);
+    const result = await execute({ queryScope: { tenant: { $in: ['a'] } } });
+    expect(result.map((r: any) => r.name)).toEqual(['a-one', 'a-two']);
+  });
+
+  it('findScoped merges an extra filter on top of the scope', async () => {
+    const { execute } = ht.findScoped(FakeModel, { name: 'a-two' });
+    const result = await execute({ queryScope: { tenant: { $in: ['a'] } } });
+    expect(result.map((r: any) => r.name)).toEqual(['a-two']);
+  });
+
+  it('loadScopedTo stores the scoped rows under the given key', async () => {
+    const { loadResources } = ht.loadScopedTo(FakeModel, 'items');
+    const out: any = await loadResources({
+      queryScope: { tenant: { $in: ['b'] } },
+    });
+    expect(out.items.map((r: any) => r.name)).toEqual(['b-one']);
+  });
+});

--- a/test/next-adapter.test.ts
+++ b/test/next-adapter.test.ts
@@ -1,6 +1,9 @@
 import { NextRequest } from 'next/server';
 import { describe, expect, it } from 'vitest';
-import { HipForbidden, HipRedirect } from '../src/errors';
+import { z } from 'zod';
+import { HTPipe } from '../src';
+import { HipConflict, HipForbidden, HipRedirect } from '../src/errors';
+import { htZodFactory } from '../src/zod';
 import { defineNextHandler, toNextHandler } from '../src/next';
 
 function postReq(url: string, body: any): NextRequest {
@@ -135,5 +138,58 @@ describe('toNextHandler', () => {
     );
     expect([302, 307]).toContain(res.status);
     expect(res.headers.get('location')).toBe('http://localhost/login');
+  });
+});
+
+describe('error detail on the wire (Finding P0-3)', () => {
+  it('a zod sanitize failure responds 422 with issues (paths+messages only)', async () => {
+    const { SanitizeInputsSliceWithZod } = htZodFactory();
+    const handler = toNextHandler(
+      HTPipe(
+        SanitizeInputsSliceWithZod('body', z.object({ name: z.string() })),
+        {
+          sanitizeInputs: (i: any) => i,
+          preAuthorize: () => true,
+          finalAuthorize: () => true,
+          execute: () => ({}),
+          redactResponse: (u: any) => u,
+        }
+      ) as any
+    );
+    const res = await handler(
+      postReq('http://localhost/api/x', { name: 12345678901 }),
+      routeCtx({})
+    );
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toBe('body not valid');
+    expect(body.issues[0].path).toEqual(['name']);
+    expect(typeof body.issues[0].message).toBe('string');
+    expect(JSON.stringify(body)).not.toContain('12345678901');
+  });
+
+  it('an exposed HipConflict detail reaches the client', async () => {
+    const handler = toNextHandler({
+      sanitizeInputs: (i: any) => i,
+      preAuthorize: () => true,
+      finalAuthorize: () => true,
+      execute: () => {
+        throw new HipConflict(
+          'blocked',
+          { blockedBy: ['a'] },
+          { expose: true }
+        );
+      },
+      redactResponse: (u: any) => u,
+    });
+    const res = await handler(
+      postReq('http://localhost/api/x', {}),
+      routeCtx({})
+    );
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: 'blocked',
+      detail: { blockedBy: ['a'] },
+    });
   });
 });

--- a/test/next-adapter.test.ts
+++ b/test/next-adapter.test.ts
@@ -143,10 +143,10 @@ describe('toNextHandler', () => {
 
 describe('error detail on the wire (Finding P0-3)', () => {
   it('a zod sanitize failure responds 422 with issues (paths+messages only)', async () => {
-    const { SanitizeInputsSliceWithZod } = htZodFactory();
+    const { SanitizeInputsSlicesWithZod } = htZodFactory();
     const handler = toNextHandler(
       HTPipe(
-        SanitizeInputsSliceWithZod('body', z.object({ name: z.string() })),
+        SanitizeInputsSlicesWithZod({ body: z.object({ name: z.string() }) }),
         {
           sanitizeInputs: (i: any) => i,
           preAuthorize: () => true,

--- a/test/next-adapter.test.ts
+++ b/test/next-adapter.test.ts
@@ -193,3 +193,141 @@ describe('error detail on the wire (Finding P0-3)', () => {
     });
   });
 });
+
+describe('adapter options (Findings P1-5, P1-6, P2-12.2)', () => {
+  const okStages = {
+    sanitizeInputs: (i: any) => i,
+    preAuthorize: () => true,
+    loadResources: () => ({ thing: { id: 't1' } }),
+    finalAuthorize: () => true,
+    execute: () => ({ made: true }),
+    redactResponse: (u: any) => u,
+  };
+
+  it('onError receives the original error (via cause) on a 500 path', async () => {
+    const seen: unknown[] = [];
+    const dbDown = new Error('db down');
+    const handler = toNextHandler(
+      {
+        ...okStages,
+        loadResources: () => {
+          throw dbDown;
+        },
+      },
+      { onError: (e) => seen.push(e) }
+    );
+    const res = await handler(
+      postReq('http://localhost/api/x', {}),
+      routeCtx({})
+    );
+    expect(res.status).toBe(500);
+    expect(seen).toHaveLength(1);
+    expect((seen[0] as Error).cause).toBe(dbDown);
+  });
+
+  it('a throwing onError does not change the response', async () => {
+    const handler = toNextHandler(
+      {
+        ...okStages,
+        execute: () => {
+          throw new Error('boom');
+        },
+      },
+      {
+        onError: () => {
+          throw new Error('logging is broken too');
+        },
+      }
+    );
+    const res = await handler(
+      postReq('http://localhost/api/x', {}),
+      routeCtx({})
+    );
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'Internal server error' });
+  });
+
+  it('afterResponse receives the final context (inputs, resources, response)', async () => {
+    let ctx: any;
+    const handler = toNextHandler(okStages, {
+      afterResponse: (c) => {
+        ctx = c;
+      },
+    });
+    const res = await handler(
+      postReq('http://localhost/api/x?q=1', { name: 'n' }),
+      routeCtx({ id: '9' })
+    );
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(ctx).toBeDefined();
+    expect(ctx.inputs.body).toEqual({ name: 'n' });
+    expect(ctx.inputs.params).toEqual({ id: '9' });
+    expect(ctx.thing).toEqual({ id: 't1' });
+    expect(ctx.response).toEqual({ made: true });
+  });
+
+  it('afterResponse does not fire on a failed request', async () => {
+    let fired = false;
+    const handler = toNextHandler(
+      {
+        ...okStages,
+        finalAuthorize: () => false,
+      },
+      {
+        afterResponse: () => {
+          fired = true;
+        },
+      }
+    );
+    const res = await handler(
+      postReq('http://localhost/api/x', {}),
+      routeCtx({})
+    );
+    expect(res.status).toBe(403);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fired).toBe(false);
+  });
+
+  it('a malformed JSON body responds 422 by default', async () => {
+    const handler = toNextHandler(okStages);
+    const res = await handler(
+      new NextRequest('http://localhost/api/x', {
+        method: 'POST',
+        body: '{not json',
+        headers: { 'content-type': 'application/json' },
+      }),
+      routeCtx({})
+    );
+    expect(res.status).toBe(422);
+    expect((await res.json()).error).toBe('Malformed JSON body');
+  });
+
+  it('allowMalformedBody restores coerce-to-{} and an empty body still passes', async () => {
+    const seenBodies: any[] = [];
+    const strategy = {
+      ...okStages,
+      sanitizeInputs: (i: any) => {
+        seenBodies.push(i.body);
+        return i;
+      },
+    };
+    const lenient = toNextHandler(strategy, { allowMalformedBody: true });
+    const malformed = await lenient(
+      new NextRequest('http://localhost/api/x', {
+        method: 'POST',
+        body: '{not json',
+        headers: { 'content-type': 'application/json' },
+      }),
+      routeCtx({})
+    );
+    expect(malformed.status).toBe(200);
+    const strict = toNextHandler(strategy);
+    const empty = await strict(
+      new NextRequest('http://localhost/api/x', { method: 'POST' }),
+      routeCtx({})
+    );
+    expect(empty.status).toBe(200);
+    expect(seenBodies).toEqual([{}, {}]);
+  });
+});

--- a/test/next-adapter.test.ts
+++ b/test/next-adapter.test.ts
@@ -101,7 +101,7 @@ describe('toNextHandler', () => {
     expect(await res.json()).toEqual({ error: 'denied' });
   });
 
-  it('returns a 500 with the uncaught-exception message on an unexpected throw', async () => {
+  it('returns a 500 with the standard scrub message on an unexpected throw', async () => {
     const handler = toNextHandler({
       sanitizeInputs: (i: any) => i,
       preAuthorize: () => true,
@@ -116,7 +116,7 @@ describe('toNextHandler', () => {
       routeCtx({})
     );
     expect(res.status).toBe(500);
-    expect(await res.json()).toEqual({ error: 'Uncaught exception' });
+    expect(await res.json()).toEqual({ error: 'Internal server error' });
   });
 
   it('issues a redirect on a HipRedirect', async () => {

--- a/test/zod.test.ts
+++ b/test/zod.test.ts
@@ -109,3 +109,39 @@ describe('stripIdTransform', () => {
     expect(stripIdTransform({ _id: 'x', a: 1 })).toEqual({ a: 1 });
   });
 });
+
+describe('SanitizeInputsSlicesWithZod', () => {
+  const { SanitizeInputsSlicesWithZod } = htZodFactory();
+  const shapes = {
+    params: z.object({ id: z.string() }),
+    body: z.object({ name: z.string() }),
+  };
+
+  it('validates every named slice and passes unnamed slices through', () => {
+    const { sanitizeInputs } = SanitizeInputsSlicesWithZod(shapes);
+    const result = sanitizeInputs({
+      params: { id: '7' },
+      body: { name: 'hip' },
+      headers: { untouched: true },
+    });
+    expect(result.params).toEqual({ id: '7' });
+    expect(result.body).toEqual({ name: 'hip' });
+    expect(result.headers).toEqual({ untouched: true });
+  });
+
+  it('throws HipBadInputs naming the offending slice', () => {
+    const { sanitizeInputs } = SanitizeInputsSlicesWithZod(shapes);
+    expect(() =>
+      sanitizeInputs({ params: { id: '7' }, body: { name: 42 } })
+    ).toThrow('body not valid');
+  });
+
+  it('strips _id from each validated slice', () => {
+    const { sanitizeInputs } = SanitizeInputsSlicesWithZod({
+      body: z.object({ name: z.string(), _id: z.string() }),
+    });
+    expect(sanitizeInputs({ body: { name: 'hip', _id: 'nope' } }).body).toEqual(
+      { name: 'hip' }
+    );
+  });
+});

--- a/test/zod.test.ts
+++ b/test/zod.test.ts
@@ -5,7 +5,7 @@ import { htZodFactory } from '../src/zod';
 
 const {
   SanitizeInputsWithZod,
-  SanitizeInputsSliceWithZod,
+  SanitizeInputsSlicesWithZod,
   RedactResponseWithZod,
   PojoToValidated,
   stripIdTransform,
@@ -40,30 +40,30 @@ describe('SanitizeInputsWithZod', () => {
   });
 });
 
-describe('SanitizeInputsSliceWithZod', () => {
+describe('SanitizeInputsSlicesWithZod (single slice)', () => {
   const params = z.object({ id: z.string() });
 
-  it('sanitizes only the named slice and passes the rest through', () => {
-    const { sanitizeInputs } = SanitizeInputsSliceWithZod('params', params);
+  it('sanitizes the named slice; unnamed slices are not named keys', () => {
+    const { sanitizeInputs } = SanitizeInputsSlicesWithZod({ params });
     const result = sanitizeInputs({
       params: { id: '7' },
       body: { untouched: true },
     });
     expect(result.params).toEqual({ id: '7' });
-    expect(result.body).toEqual({ untouched: true });
+    expect(Object.keys(result)).toEqual(['params']);
   });
 
   it('throws HipBadInputs naming the slice when the slice is invalid', () => {
-    const { sanitizeInputs } = SanitizeInputsSliceWithZod('params', params);
+    const { sanitizeInputs } = SanitizeInputsSlicesWithZod({ params });
     expect(() => sanitizeInputs({ params: {} })).toThrow('params not valid');
   });
 
-  it('accepts missing fields when partial: true', () => {
+  it('partial updates: pass schema.partial() yourself', () => {
     const strict = z.object({ id: z.string(), name: z.string() });
-    const { sanitizeInputs } = SanitizeInputsSliceWithZod('params', strict, {
-      partial: true,
+    const { sanitizeInputs } = SanitizeInputsSlicesWithZod({
+      params: strict.partial(),
     });
-    expect((sanitizeInputs({ params: { id: '7' } }) as any).params).toEqual({
+    expect(sanitizeInputs({ params: { id: '7' } }).params).toEqual({
       id: '7',
     });
   });
@@ -111,13 +111,12 @@ describe('stripIdTransform', () => {
 });
 
 describe('SanitizeInputsSlicesWithZod', () => {
-  const { SanitizeInputsSlicesWithZod } = htZodFactory();
   const shapes = {
     params: z.object({ id: z.string() }),
     body: z.object({ name: z.string() }),
   };
 
-  it('validates every named slice and passes unnamed slices through', () => {
+  it('validates every named slice; unnamed slices do not become named keys', () => {
     const { sanitizeInputs } = SanitizeInputsSlicesWithZod(shapes);
     const result = sanitizeInputs({
       params: { id: '7' },
@@ -126,7 +125,7 @@ describe('SanitizeInputsSlicesWithZod', () => {
     });
     expect(result.params).toEqual({ id: '7' });
     expect(result.body).toEqual({ name: 'hip' });
-    expect(result.headers).toEqual({ untouched: true });
+    expect(Object.keys(result).sort()).toEqual(['body', 'params']);
   });
 
   it('throws HipBadInputs naming the offending slice', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,11 @@ export default defineConfig({
   test: {
     include: ['test/**/*.test.ts'],
     exclude: ['test-build/**', 'node_modules/**'],
+    typecheck: {
+      enabled: true,
+      include: ['test/**/*.test-d.ts'],
+      tsconfig: './tsconfig.test.json',
+    },
     coverage: {
       provider: 'v8',
       include: ['src/**'],


### PR DESCRIPTION
## What does this PR do?

Fixes the 12 findings from dogfooding hipthrusts against a real Payload-CMS-migration workload, plus three follow-up design changes agreed in review. Verified end-to-end from clean: build, `attw` exports check, dual-format smoke, 167 runtime + type-level tests, tsc, lint. Version bumped to **0.12.0** (not published — the npm `0.11.0` tarball predates the module split and must never be republished with new content).

### Bug fixes (the compiler/runtime lied)

- **Piped slice types no longer lose the left slice** (`e860582`): `PipedSanitizeInputs` kept only the right fragment's return type, so the README's own multi-slice example failed to typecheck. The composed return now merges named slice keys through slice-style fragments.
- **`HTPipe` passes non-stage keys through** (`27da9a5`): a `responseMeta: { status: 201 }` on a piped fragment was silently dropped (endpoints quietly returned 200). Non-stage keys now survive composition with right-wins semantics, at runtime and in the types.
- **Unknown stage errors no longer masquerade as 403/404** (`c1b4cf2`, **breaking**): a dropped DB connection in `loadResources` used to surface as `404 Resource not found` with the original error discarded. Unknown (non-`HipError`) throws from `preAuthorize`/`loadResources`/`finalAuthorize`/`execute` now become `HipInternal` (500) with the original chained as `Error.cause`; input stages keep 422 (also with `cause`). 404 remains the deliberate signal (`HipNotFound` / `findByIdRequired`). One uniform scrub message: `"Internal server error"` (`INTERNAL_ERROR_MESSAGE`).

### Structured errors on the wire

- **`hipErrorToBody`** (`f796b75`): HTTP error bodies are now `{ error, issues?, detail? }`. A ZodError-like `detail` (duck-typed — no zod import in core) is projected to `issues: [{ path, message }]` — never received input values. Arbitrary `detail` requires the explicit `{ expose: true }` constructor opt-in; `HipInternal` exposes nothing. This unblocks per-field form errors downstream.
- **Express drops `@hapi/boom`** (`40afe87`, **breaking**): `toExpressHandler` now responds to errors directly like the other adapters; apps with their own error middleware pass `{ delegateErrors: true }` and translate via `hipErrorToStatus`/`hipErrorToBody`. The last Boom dependency is gone.

### Adapter options (`3072116`, partially breaking)

All HTTP adapters accept an options object:
- `onError(error, { raw })` — observability hook; with cause-chaining, `error.cause` is the real underlying failure. A throwing hook never affects the response.
- `afterResponse(context)` — now receives the final lifecycle context (inputs, ambient, resources, response) and fires only after a *successful* lifecycle.
- Next/Hono: non-empty malformed JSON bodies now respond `422` instead of silently becoming `{}` (`allowMalformedBody: true` opts out).

### Strict sanitization — the guarantee (`1d5d414`, **breaking**)

Nothing reaches the stages after `sanitizeInputs` except what a sanitizer explicitly returned. Chained slice sanitizers pass the raw remainder to each other out-of-band under the exported `UNSAFE_SLICES` symbol, and core deletes that channel when the stage completes — so an unsanitized slice never survives, at runtime **or** in the types (consuming one downstream is a deps-met compile error). Explicit passthrough is one no-op away: `SanitizeInputsSlices({ query: (q) => q })`. tRPC-style whole-object sanitizers are untouched.

### API renames (**breaking**, same commit)

The slice API is now plural-only and stage-prefixed: `SanitizeInputsSlices({ params: fn })`, `SanitizeInputsSlicesWithZod({ params: Schema })`, `SanitizeInputsSlicesWithMongoose({ params: Factory })`. Deleted: `WithInputSlice` (mixin-era fossil), `SanitizeInputsSliceWithZod`, `SanitizeInputsSliceWithMongoose`, and the zod `partial` option (pass `Schema.partial()` yourself).

### Type-machinery & DX

- `HTPipe` typed overloads extended to **8 fragments** (`25bfd15`); the naive extension regressed tsc from ~6s to ~2min, so the 5–8 arities use relaxed per-fragment constraints (mismatches still fail at the adapter's deps-met boundary) and a flat tuple-based passthrough fold. Typecheck stays ~5s.
- **Readable deps-met diagnostics** (`e015d50`): an unmet context dependency now errors as `HipDepNotMet<"finalAuthorize", "doc">` instead of collapsing to `never`; `any`-typed context keys and union stage returns (e.g. `{} | { doc }`) are tolerated.
- `redactResponse(unsafe, context?)` (`152f070`): redactors can branch on the final context (role-dependent redaction); two-param redactors' context keys participate in deps-met.

### Tenant scoping for list endpoints (`946a40a`, reworked in `1d5d414`)

Authorization-as-query-scope: a fragment contributes `queryScope`, and `htMongooseFactory`'s `findScoped(Model, extraFilter?, docsKey?)` / `loadScopedTo(Model, key, extraFilter?)` compose it into `Model.find` while **type-requiring** it — forgetting the tenant filter is now a compile error. `findScoped` is two-stage: the query runs on the load stage (rows in context for `finalAuthorize`/`redactResponse`/downstream `execute`) with a trivial mapping execute.

### Docs & infra

- New README sections: error-body shape, adapter options, "Input slices & the strictness guarantee", "List endpoints & tenant scoping", "Type troubleshooting", 403-vs-404 callout, minimum `moduleResolution` note.
- Type-level test suite via `vitest --typecheck` (`test/*.test-d.ts`); `prepack` cleans and rebuilds so `pnpm pack` can never ship a stale `lib/`.
- CHANGELOG documents every breaking change with migration notes.

## Checklist

- [x] Tests added/updated (type-level tests for changes to the type machinery)
- [x] `pnpm test`, `pnpm lint`, `pnpm typecheck`, and `pnpm build` pass locally
- [x] Docs updated (README / examples) if the public API changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ieCnJaVTFjPCDBcsffW9y