### PR TITLE
Add finishPipe, everyday mongoose loaders, and ctxRef specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,10 +45,15 @@ up._
   canonical (matching every other fragment factory); the camelCase
   `findScoped`/`loadScopedTo` factory entries remain as aliases, and a bare
   string third argument to `FindScoped` is still accepted as the docs key.
-- `RedactResponseByRoleWithZod(selector, schemas)` (`hipthrusts/zod`): picks
-  the wire schema by a context-derived key (boolean flag or role string), so
-  role-dependent response shapes are one declarative fragment. The selector's
-  context requirement participates in deps-met.
+- Switch composers (core): `RedactResponseSwitch(ctxKeyPath, cases)` picks
+  ONE simple redact fragment by the value at a context dot path ("a key of a
+  key": `'principal.role'`) — the composed fragment type-REQUIRES that
+  context key via deps-met, and cases are ordinary fragments
+  (`RedactResponse`, `RedactResponseWithZod`, ...), so contextual redaction
+  is a layer over the basic redactors, not a separate mechanism.
+  `SanitizeInputsSwitch(inputsKeyPath, cases)` is the sanitize-stage twin;
+  its discriminator lives in the unsafe inputs (sanitization runs before any
+  context exists) and an unmatched key rejects with `HipBadInputs`.
 - Adapter preset factories: `makeExpressHandlerFactory`,
   `makeHonoHandlerFactory`, `makeFastifyHandlerFactory`,
   `makeNextHandlerFactory` — bake shared adapter options (e.g.
@@ -67,8 +72,8 @@ up._
 ### Docs
 
 - README: partial pipelines as the reuse unit; `finishPipe`; everyday
-  loaders + `ctxRef`; codec-style zod wire schemas; role-dependent
-  redaction; deriving update schemas from doc schemas (the
+  loaders + `ctxRef`; codec-style zod wire schemas; switch-style
+  redaction/sanitization; deriving update schemas from doc schemas (the
   `.default()`-under-`.partial()` trap); adapter preset factories;
   `defineXHandler` vs `finishPipe` division of labor.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,76 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (pre-1.0: minor releases may contain breaking changes).
 
-## [Unreleased]
+## [0.13.0] - 2026-07-17
+
+_Dogfooding feedback round 2: composability/DX gaps surfaced by three more
+rounds of real-world use on 0.12.0. No correctness fixes needed — 0.12.0 held
+up._
+
+### Added
+
+- `finishPipe(pipe, handler)` (core): compose a shared partial pipeline with
+  ONE endpoint-specific trailing handler whose stage callbacks get their
+  context parameter types **inferred from the pipe** — zero hand-written
+  annotations, phantom context keys are compile errors, and pipe-internal
+  deps-met requirements (e.g. the scoped finders' `queryScope`) still surface
+  as `HipDepNotMet` at the adapter boundary. Runtime is literally
+  `HTPipe(pipe, handler)`. The trailing handler is limited to
+  `preAuthorize`/`loadResources`/`finalAuthorize`/`execute`/`redactResponse`/
+  `responseMeta` (author extraction/sanitization in the pipe). Also exports
+  the `PipeContext<TPipe>` utility behind it.
+- Everyday mongoose loader fragments (module-level in `hipthrusts/mongoose`):
+  `LoadManyTo` (find), `LoadOneTo` (findOne), `LoadByIdRequiredTo` (findById +
+  `.lean()`, throws `HipNotFound` when missing), `LoadDocByIdRequiredTo`
+  (findById hydrated, for `.set()`/`.save()` update flows). Lean reads type as
+  `TRaw & { _id: Types.ObjectId }`; doc types are inferred from mongoose's own
+  `Model<TRaw>` via type-only imports.
+- `ctxRef('dot.path')` filter/id specs for the loaders: the fragment's context
+  REQUIREMENT is derived from the path string via template-literal types, so
+  deps-met still enforces that an earlier stage provides e.g.
+  `inputs.body.user` — with no hand-written context annotations. ctxRef-
+  resolved values are `$eq`-wrapped (and `undefined` entries pruned) so
+  user-influenced values can't smuggle query operators; literal spec values
+  pass through verbatim (the operator-filter escape hatch); a selector-
+  function overload remains for computed filters.
+- Scoped finder query options: `FindScoped(Model, extraFilter?, { sort,
+  limit, skip, projection, lean, docsKey })` and `LoadScopedTo(Model, key,
+  extraFilter?, options?)`, so real list endpoints keep pagination and
+  ordering. `queryScope` stays type-required. PascalCase names are now
+  canonical (matching every other fragment factory); the camelCase
+  `findScoped`/`loadScopedTo` factory entries remain as aliases, and a bare
+  string third argument to `FindScoped` is still accepted as the docs key.
+- `RedactResponseByRoleWithZod(selector, schemas)` (`hipthrusts/zod`): picks
+  the wire schema by a context-derived key (boolean flag or role string), so
+  role-dependent response shapes are one declarative fragment. The selector's
+  context requirement participates in deps-met.
+- Adapter preset factories: `makeExpressHandlerFactory`,
+  `makeHonoHandlerFactory`, `makeFastifyHandlerFactory`,
+  `makeNextHandlerFactory` — bake shared adapter options (e.g.
+  `gatherContext`, `onError`) into a reusable converter; per-call options
+  merge over the defaults.
+
+### Changed
+
+- Errors thrown from `afterResponse` are no longer silently swallowed: they
+  are routed to `onError` with `info.phase === 'afterResponse'` (all HTTP
+  adapters), so a failed audit write is observable. They still can never
+  affect the already-sent response.
+- `json-mask` is now loaded lazily (only `dtoSchemaObj` uses it), so
+  consumers using only the finders/loaders no longer need it installed.
+
+### Docs
+
+- README: partial pipelines as the reuse unit; `finishPipe`; everyday
+  loaders + `ctxRef`; codec-style zod wire schemas; role-dependent
+  redaction; deriving update schemas from doc schemas (the
+  `.default()`-under-`.partial()` trap); adapter preset factories;
+  `defineXHandler` vs `finishPipe` division of labor.
+
+## [0.12.0]
 
 _The entries below fold the previously-unreleased modernization work and the
-dogfooding-feedback fixes into the upcoming 0.12.0 release._
+dogfooding-feedback fixes into the 0.12.0 release._
 
 ### Added (dogfooding feedback round)
 
@@ -159,6 +225,6 @@ dogfooding-feedback fixes into the upcoming 0.12.0 release._
 - Initial public releases: Express + Mongoose oriented handler classes with
   the mandatory-stage lifecycle.
 
-[Unreleased]: https://github.com/trycatchal/hipthrusts/compare/master...HEAD
+[0.13.0]: https://github.com/trycatchal/hipthrusts/compare/28fd759...master
 [0.11.0]: https://github.com/trycatchal/hipthrusts/commit/c0fee82
 [0.10.0]: https://github.com/trycatchal/hipthrusts/commit/beb8b0d

--- a/README.md
+++ b/README.md
@@ -284,6 +284,76 @@ thingRouter.put('/:id', toExpressHandler(HTPipe(
 that needs ownership. Adding a `/things/:id/archive` endpoint takes
 roughly four lines.
 
+### Partial pipelines are the reuse unit
+
+The currying story: export a **partial pipeline** — auth, sanitization,
+loaders, anything shared — and compose it first in every endpoint. A
+typical auth pipeline lifts the (maybe-absent) principal in
+`extractAmbient` (lift-only, no denial there), then denies *and*
+contributes in `preAuthorize`. Contribute the whole principal — including
+per-request authorization data like access rows — so later stages never
+re-fetch it:
+
+```ts
+// Lift only — extraction never denies.
+const WithMaybePrincipal = ExtractAmbient((raw: NextRaw) => ({
+  principal: raw.principal as Principal | null, // from gatherContext
+}));
+
+// Deny AND contribute: after this, ctx.principal is non-null downstream.
+const RequireAuthenticated = PreAuthorize(
+  (ctx: { ambient: { principal: Principal | null } }) =>
+    ctx.ambient.principal
+      ? { principal: ctx.ambient.principal } // carries its access rows
+      : false,
+);
+
+export const Authed = HTPipe(WithMaybePrincipal, RequireAuthenticated);
+```
+
+### finishPipe: an inferred trailing handler
+
+Stage callbacks inside `HTPipe` fragments must declare the context they
+consume — `HTPipe` infers its types FROM the fragments, so contextual
+typing can't flow INTO them. For the dominant authoring shape — a shared
+partial pipeline plus ONE endpoint-specific trailing handler — use
+`finishPipe`: it computes the pipe's accumulated context from the pipe's
+*type*, so the trailing stages need **zero annotations**:
+
+```ts
+import { finishPipe } from 'hipthrusts';
+
+export const GET = toNextHandler(finishPipe(
+  HTPipe(Authed, SanitizeInputsSlicesWithZod({ params: Params })),
+  {
+    loadResources:  async (ctx) => ({          // ctx fully inferred:
+      thing: await ThingModel.findById(ctx.inputs.params.id).lean().exec(),
+    }),                                        //   principal, inputs, ambient…
+    finalAuthorize: (ctx) => ctx.thing?.ownerId === ctx.principal.id,
+    execute:        (ctx) => ctx.thing,
+    redactResponse: (unsafe) => unsafe,
+  },
+), { gatherContext });
+```
+
+Consuming a context key nothing provides is a compile error, and
+pipe-internal requirements (like the scoped finders' `queryScope`) still
+surface as `HipDepNotMet` at the adapter boundary. Runtime is literally
+`HTPipe(pipe, handler)`.
+
+Limitations, by design: the trailing handler may only declare
+`preAuthorize` / `loadResources` / `finalAuthorize` / `execute` /
+`redactResponse` / `responseMeta`. Extraction and sanitization stages
+describe the pipeline's input surface — author them in the pipe. The
+exported `PipeContext<typeof SomePipe>` utility computes a pipe's
+accumulated context type if you need it by hand.
+
+Division of labor with the per-adapter `defineXHandler` helpers: those
+give contextual typing to a single *whole* config object (and are the
+only way to get a typed adapter-raw parameter in `extractAmbient`);
+`finishPipe` covers the shared-pipe-plus-trailing-handler shape. With
+partial pipelines, `finishPipe` is usually the one you want.
+
 ## Errors
 
 The lifecycle has a small, semantic error vocabulary. Throw one of these
@@ -382,14 +452,28 @@ toNextHandler(handler, {
   // Called with every error the adapter converts to an error response
   // (redirects excluded). For unexpected failures, error.cause carries
   // the original underlying error. A throwing hook never affects the
-  // response.
-  onError: (error, { raw }) => logger.error({ err: error }),
+  // response. Errors thrown from afterResponse also land here, tagged
+  // with info.phase === 'afterResponse' — a failed audit write is
+  // observable even though the response was already sent.
+  onError: (error, { raw, phase }) => logger.error({ err: error, phase }),
 
   // Post-response side effects with the FINAL lifecycle context —
   // inputs, ambient, loaded resources, and the response. Fires only
-  // after a successful lifecycle; never blocks or breaks the response.
+  // after a successful lifecycle; never blocks or breaks the response
+  // (failures are routed to onError, above).
   afterResponse: async (ctx) => auditLog.write({ input: ctx.inputs, out: ctx.response }),
 });
+```
+
+Repeating the same options on every route? Each adapter exports a preset
+factory — `makeExpressHandlerFactory`, `makeHonoHandlerFactory`,
+`makeFastifyHandlerFactory`, `makeNextHandlerFactory` — that bakes
+defaults into a reusable converter (per-call options merge over them):
+
+```ts
+export const toAppHandler = makeNextHandlerFactory({ gatherContext, onError });
+// ...
+export const GET = toAppHandler(handler); // no repeated { gatherContext }
 ```
 
 The Next.js and Hono adapters (which parse JSON bodies themselves)
@@ -411,8 +495,7 @@ scope a *typed context dependency* instead of a convention: one fragment
 contributes `queryScope`, and the scoped finders require it.
 
 ```ts
-import { htMongooseFactory } from 'hipthrusts/mongoose';
-const { findScoped } = htMongooseFactory(mongoose);
+import { FindScoped } from 'hipthrusts/mongoose';
 
 const WithTenantScope = LoadResources((ctx: { ambient: { user: User } }) => ({
   queryScope: { businessGroup: { $in: ctx.ambient.user.accessibleGroupIds } },
@@ -425,21 +508,29 @@ app.get('/things', toExpressHandler(HTPipe(
     sanitizeInputs: (i) => i,
     preAuthorize:   (ctx) => !!ctx.ambient.user,
     finalAuthorize: () => true,
-    ...findScoped(ThingModel),          // Model.find({ ...ctx.queryScope })
+    ...FindScoped(ThingModel, undefined, {   // Model.find({ ...ctx.queryScope })
+      sort: { createdAt: -1 },
+      limit: 100,
+    }),
     redactResponse: (rows) => rows.map(({ id, name }) => ({ id, name })),
   },
 )));
 ```
 
-`findScoped(Model, extraFilter?, docsKey?)` is a two-stage fragment: the
+`FindScoped(Model, extraFilter?, options?)` is a two-stage fragment: the
 scoped `Model.find` runs on the **load** stage (so the rows sit in
 context — under `scopedDocs` by default — where `finalAuthorize`, a
 two-param `redactResponse`, and any downstream `execute` you pipe can
 see them) plus a trivial `execute` that returns them. Its load stage
 **requires** `queryScope` in its context type — drop `WithTenantScope`
-from the pipe and the handler no longer compiles. `loadScopedTo(Model,
-key, extraFilter?)` is the load stage alone, for handlers that
-post-process the scoped rows in their own `execute`.
+from the pipe and the handler no longer compiles. The options bag takes
+`{ sort, limit, skip, projection, lean, docsKey }`, so real list
+endpoints keep their pagination and ordering. `LoadScopedTo(Model, key,
+extraFilter?, options?)` is the load stage alone, for handlers that
+post-process the scoped rows in their own `execute`. (The camelCase
+`findScoped`/`loadScopedTo` names on `htMongooseFactory` remain as
+aliases; a bare string third argument to `FindScoped` is still accepted
+as the docs key.)
 
 ## Type troubleshooting
 
@@ -507,6 +598,73 @@ A Zod parse failure throws `HipBadInputs` carrying the `ZodError` as
 
 For partial-update endpoints, pass `Body.partial()` as the slice schema.
 
+#### Codec-style wire schemas
+
+Make the wire schema a zod **codec**: it accepts the STORED document and
+its transforms own the whole reshape (`_id` → `id`, ObjectId → string,
+Date → ISO, null-normalization). Redaction is then ONE fragment — no
+mapper-then-validate two-step:
+
+```ts
+const wireCodecSchema = z
+  .object({
+    _id: z.instanceof(Types.ObjectId).transform(String),
+    name: z.string(),
+    createdAt: z.date().transform((d) => d.toISOString()),
+  })
+  .transform(({ _id, ...rest }) => ({ id: _id, ...rest }));
+
+const RedactAsWire = RedactResponseWithZod(wireCodecSchema);
+```
+
+#### Role-dependent redaction
+
+When different callers get different shapes ("members see `{names}`,
+admins see `{names, emails}`"), pick the schema by a context key instead
+of hand-branching:
+
+```ts
+const { RedactResponseByRoleWithZod } = htZodFactory();
+
+// By a boolean flag some auth stage contributed:
+RedactResponseByRoleWithZod((ctx: { canSeeEmails: boolean }) => ctx.canSeeEmails, {
+  true: adminWireSchema,
+  false: memberWireSchema,
+});
+
+// ...or keyed by a role string:
+RedactResponseByRoleWithZod((ctx: { role: 'admin' | 'member' }) => ctx.role, {
+  admin: adminWireSchema,
+  member: memberWireSchema,
+});
+```
+
+The selector's context requirement participates in deps-met like any
+two-parameter redactor's: if nothing contributes `canSeeEmails`, the
+handler doesn't compile.
+
+#### Deriving input schemas from document schemas
+
+Deriving a PATCH schema from the stored-document schema has a trap: zod
+fires `.default()` **even under `.partial()`**, so a derived update
+schema silently injects defaulted fields into every update — e.g. every
+PATCH "sends" `verificationComplete: false` and then trips your
+privileged-field check with a 403. Derive input schemas with
+pick/partial AND strip defaults:
+
+```ts
+// DON'T: docSchema.partial() — .default() fields materialize on every parse.
+// DO: pick the client-writable fields and re-declare them default-free:
+const UpdateBody = z.object({
+  name: docShape.name,             // reuse field validators...
+  description: docShape.description,
+}).partial();                      // ...but only ones without .default()
+```
+
+If a field needs a default at CREATE time, keep the default on the
+create schema (or the DB layer) — never on a schema an update derives
+from.
+
 ### Mongoose
 
 ```ts
@@ -522,6 +680,55 @@ const {
 ```
 
 These compose with `HTPipe` like everything else.
+
+#### Everyday loaders & ctxRef
+
+The everyday findById/findOne/find `loadResources` blocks are one-liners
+(module-level exports — no factory needed). Filter values and ids are
+declared as **context paths** with `ctxRef`, and the fragment's context
+*requirement* is derived from the path string — deps-met still enforces
+that an earlier stage provides `inputs.body.user`, with zero
+hand-written context annotations:
+
+```ts
+import {
+  ctxRef, LoadManyTo, LoadOneTo, LoadByIdRequiredTo, LoadDocByIdRequiredTo,
+} from 'hipthrusts/mongoose';
+
+/** find -> ctx.things: Lean<Thing>[] */
+LoadManyTo(ThingModel, 'things', {
+  businessGroup: ctxRef('inputs.params.businessGroupId'),
+  archived: false,                     // literal: passed through verbatim
+})
+/** findOne -> ctx.user: Lean<User> | null */
+LoadOneTo(UserModel, 'user', { _id: ctxRef('inputs.body.user') })
+/** findById + .lean(), throws HipNotFound -> ctx.thing: Lean<Thing> */
+LoadByIdRequiredTo(ThingModel, 'thing', ctxRef('inputs.params.id'), 'No such thing')
+/** findById HYDRATED (for .set()/.save() update flows), throws HipNotFound */
+LoadDocByIdRequiredTo(ThingModel, 'thingDoc', ctxRef('inputs.params.id'))
+```
+
+Semantics worth knowing:
+
+- **`$eq`-wrapping by default.** ctxRef-resolved values are wrapped in
+  `{ $eq: value }` (and `undefined` entries pruned), so user-influenced
+  context values can't smuggle query operators. Literal values in the
+  spec are developer-authored and pass through verbatim — that's the
+  escape hatch for operator filters like `{ status: { $in: [...] } }`.
+  Every loader also accepts a selector function
+  (`(ctx) => ({ tenant: { $in: ctx.tenantIds } })`) for computed
+  filters, passed through as-is.
+- **Lean by default.** `LoadManyTo`/`LoadOneTo`/`LoadByIdRequiredTo`
+  read `.lean()` and type rows as `TRaw & { _id: Types.ObjectId }`, so a
+  downstream stage declaring `_id` passes deps-met. Use
+  `LoadDocByIdRequiredTo` when you need a hydrated document to mutate
+  and save.
+- **404 is the short pattern.** The `RequiredTo` variants throw
+  `HipNotFound` (with your optional message) when the row is missing —
+  reserving `finalAuthorize`/403 for actual permission denials.
+- These are typed against mongoose's own `Model<TRaw>` via type-only
+  imports (they erase at runtime; mongoose stays an optional peer), so
+  the raw doc type is inferred from the model you pass.
 
 ## tRPC adapter
 

--- a/README.md
+++ b/README.md
@@ -617,31 +617,48 @@ const wireCodecSchema = z
 const RedactAsWire = RedactResponseWithZod(wireCodecSchema);
 ```
 
-#### Role-dependent redaction
+#### Switch-style redaction & sanitization
 
-When different callers get different shapes ("members see `{names}`,
-admins see `{names, emails}`"), pick the schema by a context key instead
-of hand-branching:
+When different requests get different shapes, don't hand-branch inside
+one stage — compose *simple* fragments with a switch. The core
+`RedactResponseSwitch(ctxKeyPath, cases)` picks one ordinary redact
+fragment by the value found at a context dot path (a key of a key works:
+`'principal.role'`), and the chosen case receives the unsafe response
+and the context exactly as if it were the handler's own redactor:
 
 ```ts
-const { RedactResponseByRoleWithZod } = htZodFactory();
+import { RedactResponseSwitch } from 'hipthrusts';
 
-// By a boolean flag some auth stage contributed:
-RedactResponseByRoleWithZod((ctx: { canSeeEmails: boolean }) => ctx.canSeeEmails, {
-  true: adminWireSchema,
-  false: memberWireSchema,
-});
-
-// ...or keyed by a role string:
-RedactResponseByRoleWithZod((ctx: { role: 'admin' | 'member' }) => ctx.role, {
-  admin: adminWireSchema,
-  member: memberWireSchema,
+// "members see {names}, admins see {names, emails}" — but the switch is
+// general-purpose: any context key, any simple redact fragments.
+RedactResponseSwitch('canSeeEmails', {
+  true: RedactResponseWithZod(adminWireSchema),
+  false: RedactResponseWithZod(memberWireSchema),
 });
 ```
 
-The selector's context requirement participates in deps-met like any
-two-parameter redactor's: if nothing contributes `canSeeEmails`, the
-handler doesn't compile.
+The composed fragment type-REQUIRES the context key (derived from the
+path string): if nothing contributes `canSeeEmails`, the handler doesn't
+compile. An unmatched key at runtime is a `HipInternal` (server bug).
+
+`SanitizeInputsSwitch(inputsKeyPath, cases)` is the same idea for the
+sanitize stage. Sanitization runs before any context exists, so the
+discriminator lives in the unsafe inputs themselves — the
+discriminated-union endpoint story:
+
+```ts
+import { SanitizeInputsSwitch } from 'hipthrusts';
+
+SanitizeInputsSwitch('body.kind', {
+  email: SanitizeInputsSlicesWithZod({ body: EmailBody }),
+  sms:   SanitizeInputsSlicesWithZod({ body: SmsBody }),
+});
+```
+
+An unmatched discriminator rejects the request with `HipBadInputs`
+(422). Both switches work with ANY simple fragments — zod-backed,
+mongoose-backed, or hand-written `RedactResponse`/`SanitizeInputs` — the
+switch is just a layer over them.
 
 #### Deriving input schemas from document schemas
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hipthrusts",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/trycatchal/hipthrusts.git"

--- a/src/express.ts
+++ b/src/express.ts
@@ -202,7 +202,15 @@ export function toExpressHandler<
       }
       if (options.afterResponse) {
         res.on('finish', () =>
-          safeInvokeAfterResponse(options.afterResponse, context)
+          safeInvokeAfterResponse(
+            options.afterResponse,
+            context,
+            options.onError,
+            {
+              req,
+              res,
+            }
+          )
         );
       }
       res.status(meta.status || 200).json(response);
@@ -220,5 +228,23 @@ export function toExpressHandler<
         res.status(500).json({ error: 'Internal server error' });
       }
     }
+  };
+}
+
+// Adapter preset factory: bakes shared options into a reusable handler
+// converter (mirrors makeNextHandlerFactory); per-call options merge OVER
+// the defaults.
+export function makeExpressHandlerFactory(defaults: HipExpressHandlerOptions) {
+  return function toExpressHandlerWithDefaults<
+    TConf extends OptionalStagesShape &
+      HasRequiredStages &
+      PreAuthorizeDepsMet<TConf> &
+      LoadResourcesDepsMet<TConf> &
+      FinalAuthorizeDepsMet<TConf> &
+      ExecuteDepsMet<TConf> &
+      RedactResponseDepsMet<TConf> &
+      HasResponseMeta,
+  >(handlingStrategy: TConf, options: HipExpressHandlerOptions = {}) {
+    return toExpressHandler(handlingStrategy, { ...defaults, ...options });
   };
 }

--- a/src/fastify.ts
+++ b/src/fastify.ts
@@ -102,7 +102,15 @@ export function toFastifyHandler<
       if (options.afterResponse) {
         // Fastify is Node-only; schedule off the response path.
         setImmediate(() =>
-          safeInvokeAfterResponse(options.afterResponse, context)
+          safeInvokeAfterResponse(
+            options.afterResponse,
+            context,
+            options.onError,
+            {
+              req,
+              reply,
+            }
+          )
         );
       }
       return reply.status(meta.status || 200).send(response);
@@ -119,5 +127,23 @@ export function toFastifyHandler<
       }
       return reply.status(500).send({ error: 'Internal server error' });
     }
+  };
+}
+
+// Adapter preset factory: bakes shared options into a reusable handler
+// converter (mirrors makeNextHandlerFactory); per-call options merge OVER
+// the defaults.
+export function makeFastifyHandlerFactory(defaults: HttpAdapterOptions) {
+  return function toFastifyHandlerWithDefaults<
+    TConf extends OptionalStagesShape &
+      HasRequiredStages &
+      PreAuthorizeDepsMet<TConf> &
+      LoadResourcesDepsMet<TConf> &
+      FinalAuthorizeDepsMet<TConf> &
+      ExecuteDepsMet<TConf> &
+      RedactResponseDepsMet<TConf> &
+      HasResponseMeta,
+  >(handlingStrategy: TConf, options: HttpAdapterOptions = {}) {
+    return toFastifyHandler(handlingStrategy, { ...defaults, ...options });
   };
 }

--- a/src/finish-pipe.ts
+++ b/src/finish-pipe.ts
@@ -1,0 +1,275 @@
+// finishPipe: compose a shared partial pipeline (auth, sanitization, loaders)
+// with ONE endpoint-specific trailing handler — the dominant authoring shape —
+// such that the trailing handler's stage callbacks get their context parameter
+// types INFERRED from the pipe. HTPipe can't do this by itself: it infers its
+// type parameters FROM the fragments, so contextual typing can't flow INTO
+// them and every stage callback must hand-declare the context it consumes.
+// finishPipe computes the pipe's accumulated context from the pipe's TYPE
+// instead, so trailing stages need zero annotations and consuming a phantom
+// context key is a compile error.
+//
+// Limitations (by design):
+// - The trailing handler may only declare preAuthorize / loadResources /
+//   finalAuthorize / execute / redactResponse / responseMeta. Extraction and
+//   sanitization stages describe the pipeline's input surface — author them in
+//   the pipe (excess-property checking rejects them here).
+// - Runtime is literally HTPipe(pipe, handler): pipe stages run first, the
+//   handler's stages run after, contributions merge exactly as HTPipe merges
+//   them.
+// - The composed type keeps the PIPE's stage input requirements visible, so
+//   pipe-internal deps-met requirements (e.g. findScoped's `queryScope`) still
+//   surface through the adapters as HipDepNotMet.
+import { HTPipe } from './index.js';
+import { ResponseMeta } from './http-adapter.js';
+import { AllStageKeys, PromiseOrSync, UNSAFE_SLICES } from './types.js';
+
+// Strips index signatures, keeping only statically-known keys (mirrors the
+// KnownKeys used for HTPipe's sanitize merging).
+type KnownKeys<T> = {
+  [K in keyof T as string extends K
+    ? never
+    : number extends K
+      ? never
+      : symbol extends K
+        ? never
+        : K]: T[K];
+};
+
+// PITFALL guard: Exclude<boolean-only-return, boolean> = never, never extends
+// object, and one never annihilates the whole context intersection — so never
+// MUST resolve to {} before the object test.
+type ObjOr<T> = [T] extends [never] ? {} : [T] extends [object] ? T : {};
+
+// What an authorization stage CONTRIBUTES to context: its object returns.
+// Boolean returns (pass/deny) contribute nothing.
+type AuthContrib<T> = ObjOr<Exclude<Awaited<T>, boolean>>;
+
+type PipeAmbient<TPipe> = TPipe extends {
+  extractAmbient: (raw: any) => infer TAmbient;
+}
+  ? { ambient: Awaited<TAmbient> }
+  : {};
+
+// KnownKeys + the explicit Omit strip the UNSAFE_SLICES raw-remainder channel
+// and any index-signature carriers from slice sanitizers, matching what core
+// actually passes downstream (SanitizedOnly at runtime).
+type PipeInputs<TPipe> = TPipe extends {
+  sanitizeInputs: (unsafe: any) => infer TSafe;
+}
+  ? { inputs: KnownKeys<Omit<Awaited<TSafe>, typeof UNSAFE_SLICES>> }
+  : {};
+
+type PipePre<TPipe> = TPipe extends {
+  preAuthorize: (context: any) => infer TOut;
+}
+  ? AuthContrib<TOut>
+  : {};
+
+type PipeLoad<TPipe> = TPipe extends {
+  loadResources: (context: any) => infer TOut;
+}
+  ? ObjOr<Awaited<TOut>>
+  : {};
+
+type PipeFinal<TPipe> = TPipe extends {
+  finalAuthorize: (context: any) => infer TOut;
+}
+  ? AuthContrib<TOut>
+  : {};
+
+type PipeExec<TPipe> = TPipe extends { execute: (context: any) => infer TOut }
+  ? Awaited<TOut>
+  : never;
+
+type PipeRedacted<TPipe> = TPipe extends {
+  redactResponse: (unsafe: any, context?: any) => infer TOut;
+}
+  ? TOut
+  : never;
+
+// Accumulated context types at each trailing-handler stage boundary.
+type CtxForPreAuthorize<TPipe> = PipeAmbient<TPipe> &
+  PipeInputs<TPipe> &
+  PipePre<TPipe>;
+type CtxForLoadResources<TPipe, TPre> = CtxForPreAuthorize<TPipe> &
+  AuthContrib<TPre> &
+  PipeLoad<TPipe>;
+type CtxForFinalAuthorize<TPipe, TPre, TLoad> = CtxForLoadResources<
+  TPipe,
+  TPre
+> &
+  ObjOr<Awaited<TLoad>> &
+  PipeFinal<TPipe>;
+type CtxForExecute<TPipe, TPre, TLoad, TFinal> = CtxForFinalAuthorize<
+  TPipe,
+  TPre,
+  TLoad
+> &
+  AuthContrib<TFinal>;
+
+// The full accumulated context a pipe provides (through finalAuthorize) — the
+// first-class utility behind finishPipe, exported for anyone computing pipe
+// context types by hand.
+export type PipeContext<TPipe> = CtxForFinalAuthorize<TPipe, never, never>;
+
+// What the trailing handler's redactResponse receives as `unsafe`: the pipe's
+// redactor output if the pipe has one (HTPipe chains redactors left-to-right),
+// otherwise the execute output (the handler's if declared, else the pipe's).
+type ExecOut<TPipe, TExec> = [TExec] extends [never]
+  ? PipeExec<TPipe>
+  : Awaited<TExec>;
+type UnsafeForRedact<TPipe, TExec> = [PipeRedacted<TPipe>] extends [never]
+  ? [ExecOut<TPipe, TExec>] extends [never]
+    ? unknown
+    : ExecOut<TPipe, TExec>
+  : PipeRedacted<TPipe>;
+
+// The stage surface the trailing handler may declare. Contextual param types
+// all derive from TPipe (and earlier handler stages' returns), so callbacks
+// need no annotations.
+export interface FinishPipeHandler<TPipe, TPre, TLoad, TFinal, TExec, TResp> {
+  preAuthorize?: (context: CtxForPreAuthorize<TPipe>) => TPre;
+  loadResources?: (context: CtxForLoadResources<TPipe, TPre>) => TLoad;
+  finalAuthorize?: (
+    context: CtxForFinalAuthorize<TPipe, TPre, TLoad>
+  ) => TFinal;
+  execute?: (context: CtxForExecute<TPipe, TPre, TLoad, TFinal>) => TExec;
+  redactResponse?: (
+    unsafe: UnsafeForRedact<TPipe, TExec>,
+    context: CtxForExecute<TPipe, TPre, TLoad, TFinal>
+  ) => TResp;
+  responseMeta?: ResponseMeta | ((ctx: any) => ResponseMeta);
+}
+
+// --- Composed result type -------------------------------------------------
+// Each stage keeps the PIPE's declared input type (that's what preserves
+// HipDepNotMet enforcement for pipe-internal deps) while claiming the merged
+// return of pipe stage + handler stage. `[THandlerReturn] extends [never]`
+// detects "handler did not declare this stage" (the generic's default).
+
+type FinishedPreAuthorize<TPipe, TPre> = TPipe extends {
+  preAuthorize: (context: infer TCtxIn) => infer TOut;
+}
+  ? [TPre] extends [never]
+    ? { preAuthorize: (context: TCtxIn) => TOut }
+    : {
+        preAuthorize: (
+          context: TCtxIn
+        ) => false | (AuthContrib<TOut> & AuthContrib<TPre>);
+      }
+  : [TPre] extends [never]
+    ? {}
+    : { preAuthorize: (context: CtxForPreAuthorize<TPipe>) => TPre };
+
+type FinishedLoadResources<TPipe, TPre, TLoad> = TPipe extends {
+  loadResources: (context: infer TCtxIn) => infer TOut;
+}
+  ? [TLoad] extends [never]
+    ? { loadResources: (context: TCtxIn) => TOut }
+    : {
+        loadResources: (
+          context: TCtxIn
+        ) => Promise<ObjOr<Awaited<TOut>> & ObjOr<Awaited<TLoad>>>;
+      }
+  : [TLoad] extends [never]
+    ? {}
+    : { loadResources: (context: CtxForLoadResources<TPipe, TPre>) => TLoad };
+
+type FinishedFinalAuthorize<TPipe, TPre, TLoad, TFinal> = TPipe extends {
+  finalAuthorize: (context: infer TCtxIn) => infer TOut;
+}
+  ? [TFinal] extends [never]
+    ? { finalAuthorize: (context: TCtxIn) => TOut }
+    : {
+        finalAuthorize: (
+          context: TCtxIn
+        ) => PromiseOrSync<false | (AuthContrib<TOut> & AuthContrib<TFinal>)>;
+      }
+  : [TFinal] extends [never]
+    ? {}
+    : {
+        finalAuthorize: (
+          context: CtxForFinalAuthorize<TPipe, TPre, TLoad>
+        ) => TFinal;
+      };
+
+type FinishedExecute<TPipe, TPre, TLoad, TFinal, TExec> = TPipe extends {
+  execute: (context: infer TCtxIn) => infer TOut;
+}
+  ? [TExec] extends [never]
+    ? { execute: (context: TCtxIn) => TOut }
+    : // HTPipe runs both executes and returns the RIGHT (handler) result.
+      { execute: (context: TCtxIn) => Promise<Awaited<TExec>> }
+  : [TExec] extends [never]
+    ? {}
+    : {
+        execute: (context: CtxForExecute<TPipe, TPre, TLoad, TFinal>) => TExec;
+      };
+
+type FinishedRedactResponse<TPipe, TPre, TLoad, TFinal, TExec, TResp> =
+  TPipe extends {
+    redactResponse: (unsafe: infer TUnsafeIn, context?: any) => infer TOut;
+  }
+    ? [TResp] extends [never]
+      ? { redactResponse: (unsafe: TUnsafeIn, context?: any) => TOut }
+      : { redactResponse: (unsafe: TUnsafeIn, context?: any) => TResp }
+    : [TResp] extends [never]
+      ? {}
+      : {
+          redactResponse: (
+            unsafe: UnsafeForRedact<TPipe, TExec>,
+            context: CtxForExecute<TPipe, TPre, TLoad, TFinal>
+          ) => TResp;
+        };
+
+type FinishedExtractStages<TPipe> = (TPipe extends {
+  extractAmbient: infer TFn extends (...args: any[]) => any;
+}
+  ? { extractAmbient: TFn }
+  : {}) &
+  (TPipe extends { extractInputs: infer TFn extends (...args: any[]) => any }
+    ? { extractInputs: TFn }
+    : {}) &
+  (TPipe extends { sanitizeInputs: infer TFn extends (...args: any[]) => any }
+    ? { sanitizeInputs: TFn }
+    : {});
+
+// Non-stage keys (e.g. responseMeta) pass through with right-wins semantics,
+// same as HTPipe.
+type NonStageKeys<T> = Omit<KnownKeys<T>, AllStageKeys>;
+
+export type FinishedPipe<TPipe, TPre, TLoad, TFinal, TExec, TResp, TMeta> =
+  FinishedExtractStages<TPipe> &
+    FinishedPreAuthorize<TPipe, TPre> &
+    FinishedLoadResources<TPipe, TPre, TLoad> &
+    FinishedFinalAuthorize<TPipe, TPre, TLoad, TFinal> &
+    FinishedExecute<TPipe, TPre, TLoad, TFinal, TExec> &
+    FinishedRedactResponse<TPipe, TPre, TLoad, TFinal, TExec, TResp> &
+    ([TMeta] extends [never]
+      ? NonStageKeys<TPipe>
+      : Omit<NonStageKeys<TPipe>, 'responseMeta'> & { responseMeta: TMeta });
+
+export function finishPipe<
+  TPipe extends object,
+  TPre = never,
+  TLoad = never,
+  TFinal = never,
+  TExec = never,
+  TResp = never,
+  TMeta extends ResponseMeta | ((ctx: any) => ResponseMeta) = never,
+>(
+  pipe: TPipe,
+  handler: FinishPipeHandler<TPipe, TPre, TLoad, TFinal, TExec, TResp> & {
+    responseMeta?: TMeta;
+  }
+): FinishedPipe<TPipe, TPre, TLoad, TFinal, TExec, TResp, TMeta> {
+  return HTPipe(pipe as any, handler as any) as unknown as FinishedPipe<
+    TPipe,
+    TPre,
+    TLoad,
+    TFinal,
+    TExec,
+    TResp,
+    TMeta
+  >;
+}

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -128,7 +128,12 @@ export function toHonoHandler<
       );
       if (options.afterResponse) {
         const runAfterResponse = () =>
-          safeInvokeAfterResponse(options.afterResponse, context);
+          safeInvokeAfterResponse(
+            options.afterResponse,
+            context,
+            options.onError,
+            raw
+          );
         try {
           // On edge runtimes waitUntil keeps the worker alive for the side
           // effect; on Node hono has no executionCtx, so fall back to a task.
@@ -158,5 +163,23 @@ export function toHonoHandler<
       }
       return c.json({ error: 'Internal server error' }, 500);
     }
+  };
+}
+
+// Adapter preset factory: bakes shared options into a reusable handler
+// converter (mirrors makeNextHandlerFactory); per-call options merge OVER
+// the defaults.
+export function makeHonoHandlerFactory(defaults: HipHonoHandlerOptions) {
+  return function toHonoHandlerWithDefaults<
+    TConf extends OptionalStagesShape &
+      HasRequiredStages &
+      PreAuthorizeDepsMet<TConf> &
+      LoadResourcesDepsMet<TConf> &
+      FinalAuthorizeDepsMet<TConf> &
+      ExecuteDepsMet<TConf> &
+      RedactResponseDepsMet<TConf> &
+      HasResponseMeta,
+  >(handlingStrategy: TConf, options: HipHonoHandlerOptions = {}) {
+    return toHonoHandler(handlingStrategy, { ...defaults, ...options });
   };
 }

--- a/src/http-adapter.ts
+++ b/src/http-adapter.ts
@@ -23,17 +23,29 @@ export interface HasResponseMeta<TCtx = any> {
   responseMeta?: ResponseMeta | ((ctx: TCtx) => ResponseMeta);
 }
 
+// Info the adapters hand to onError alongside the error itself. `phase` is
+// 'afterResponse' when the error escaped the afterResponse side-effect hook
+// (the response was already sent); absent for request-lifecycle errors.
+export interface OnErrorInfo {
+  raw?: unknown;
+  phase?: 'afterResponse';
+}
+
 // Options shared by every HTTP adapter.
 export interface HttpAdapterOptions {
   // Observability seam: called with every error the adapter converts to an
-  // error response (HipErrors and unknown failures alike; redirects excluded).
-  // With unknown-error cause-chaining, `error.cause` holds the real underlying
-  // failure. A throwing onError never affects the response.
-  onError?: (error: unknown, info: { raw?: unknown }) => void;
+  // error response (HipErrors and unknown failures alike; redirects excluded),
+  // AND with errors thrown from afterResponse (identified by
+  // info.phase === 'afterResponse') — a failed audit write is observable even
+  // though it can never affect the already-sent response. With unknown-error
+  // cause-chaining, `error.cause` holds the real underlying failure. A
+  // throwing onError never affects the response.
+  onError?: (error: unknown, info: OnErrorInfo) => void;
   // Post-response side effects (audit logs, notifications) with access to the
   // full final lifecycle context (inputs, ambient, loaded resources, response).
   // Runs only after a SUCCESSFUL lifecycle; failures never fire it. Errors
-  // thrown from it never affect the response.
+  // thrown from it never affect the response, but they are routed to onError
+  // with phase 'afterResponse'.
   afterResponse?: (context: Record<string, unknown>) => void | Promise<void>;
 }
 
@@ -41,7 +53,7 @@ export interface HttpAdapterOptions {
 export function safeInvokeOnError(
   onError: HttpAdapterOptions['onError'],
   error: unknown,
-  info: { raw?: unknown }
+  info: OnErrorInfo
 ) {
   if (!onError) {
     return;
@@ -53,19 +65,24 @@ export function safeInvokeOnError(
   }
 }
 
-// Fire-and-forget afterResponse; sync throws and async rejections are both
-// swallowed so side effects can never affect the (already sent) response.
+// Fire-and-forget afterResponse; sync throws and async rejections can never
+// affect the (already sent) response — they are routed to onError with
+// phase 'afterResponse' so failed side effects stay observable.
 export function safeInvokeAfterResponse(
   afterResponse: HttpAdapterOptions['afterResponse'],
-  context: Record<string, unknown>
+  context: Record<string, unknown>,
+  onError?: HttpAdapterOptions['onError'],
+  raw?: unknown
 ) {
   if (!afterResponse) {
     return;
   }
+  const report = (error: unknown) =>
+    safeInvokeOnError(onError, error, { raw, phase: 'afterResponse' });
   try {
-    Promise.resolve(afterResponse(context)).catch(() => {});
-  } catch {
-    // Side-effect failures are intentionally swallowed.
+    Promise.resolve(afterResponse(context)).catch(report);
+  } catch (error) {
+    report(error);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1345,3 +1345,6 @@ export * from './errors.js';
 export * from './http-adapter.js';
 export * from './user.js';
 export * from './lifecycle-functions.js';
+// finish-pipe imports HTPipe from this module; the cycle is safe because the
+// reference is only dereferenced at call time.
+export * from './finish-pipe.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { HipBadInputs, HipInternal } from './errors.js';
 import {
   authorizationPassed,
   isHasExecute,
@@ -37,6 +38,7 @@ import {
   OptionallyHasFinalAuthorize,
   OptionallyHasLoadResources,
   OptionallyHasPreAuthorize,
+  NestedPathReq,
   OptionallyHasRedactResponse,
   OptionallyHasSanitizeInputs,
   PromiseResolveOrSync,
@@ -214,6 +216,74 @@ export function SanitizeInputsSlices<
       return out as SafeSlices & HasUnsafeSlices;
     }
   );
+}
+
+function readDotPath(source: any, path: string) {
+  return path
+    .split('.')
+    .reduce((acc, segment) => (acc == null ? acc : acc[segment]), source);
+}
+
+// Switch-style input sanitization: picks ONE simple sanitize fragment from
+// `cases` by the (stringified) value found at `keyPath` on the UNSAFE inputs
+// object — the sanitize stage runs before any context exists, so the
+// discriminator can only live in the inputs themselves (e.g. 'body.kind' for
+// a discriminated-union create endpoint). An unmatched key rejects the
+// request with HipBadInputs. The chosen fragment's sanitizeInputs receives
+// the whole unsafe inputs object, so any simple sanitize fragment composes
+// here (SanitizeInputs, SanitizeInputsSlices, the zod/mongoose helpers, ...).
+export function SanitizeInputsSwitch<
+  TPath extends string,
+  TCases extends Record<string, HasSanitizeInputs<any, any>>,
+>(keyPath: TPath, cases: TCases) {
+  return SanitizeInputs(
+    (unsafeInputs: any): ReturnType<TCases[keyof TCases]['sanitizeInputs']> => {
+      const key = String(readDotPath(unsafeInputs, keyPath));
+      const chosen: HasSanitizeInputs<any, any> | undefined = cases[key];
+      if (!chosen) {
+        // Generic message: the key is untrusted input and error messages
+        // reach the client.
+        throw new HipBadInputs('Unrecognized input variant', { keyPath });
+      }
+      return chosen.sanitizeInputs(unsafeInputs);
+    }
+  );
+}
+
+// Switch-style response redaction: picks ONE simple redact fragment from
+// `cases` by the (stringified) value found at `keyPath` on the final
+// lifecycle context — a dot path, so nested keys work ('principal.role').
+// The composed fragment REQUIRES that context key (derived from the path
+// string), so deps-met makes "nothing contributes principal.role" a compile
+// error. Case values are ordinary redact fragments (RedactResponse,
+// RedactResponseWithZod, ...); the chosen one receives both the unsafe
+// response and the context, exactly as if it were the handler's own redactor:
+//   RedactResponseSwitch('canSeeEmails', {
+//     true: RedactResponseWithZod(adminWireSchema),
+//     false: RedactResponseWithZod(memberWireSchema),
+//   })
+// A key with no case is a server bug: HipInternal (the key rides `detail`,
+// which is never serialized for internal errors).
+export function RedactResponseSwitch<
+  TPath extends string,
+  TCases extends Record<string, HasRedactResponse<any, any>>,
+>(keyPath: TPath, cases: TCases) {
+  return {
+    redactResponse: (
+      unsafe: Parameters<TCases[keyof TCases]['redactResponse']>[0],
+      context: NestedPathReq<TPath>
+    ): ReturnType<TCases[keyof TCases]['redactResponse']> => {
+      const key = String(readDotPath(context, keyPath));
+      const chosen: HasRedactResponse<any, any> | undefined = cases[key];
+      if (!chosen) {
+        throw new HipInternal('No response redactor registered for key', {
+          keyPath,
+          key,
+        });
+      }
+      return chosen.redactResponse(unsafe, context);
+    },
+  };
 }
 
 export function PreAuthorizeFrom<
@@ -1339,7 +1409,7 @@ export function HTPipe(...objs: any[]) {
 }
 
 export { UNSAFE_SLICES } from './types.js';
-export type { HasUnsafeSlices, SanitizedOnly } from './types.js';
+export type { HasUnsafeSlices, NestedPathReq, SanitizedOnly } from './types.js';
 export * from './core.js';
 export * from './errors.js';
 export * from './http-adapter.js';

--- a/src/load-json-mask-cjs.cts
+++ b/src/load-json-mask-cjs.cts
@@ -1,0 +1,15 @@
+// CJS-build loader for the OPTIONAL json-mask peer — see load-json-mask.ts
+// (the ESM variant) for why this is lazy.
+export type JsonMaskFn = (obj: any, maskConfig: string) => any;
+
+export function loadJsonMask(): JsonMaskFn {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- this file is only ever built as CommonJS.
+    return require('json-mask');
+  } catch (cause) {
+    throw new Error(
+      'dtoSchemaObj requires the optional peer dependency "json-mask" — install it to use schema masking.',
+      { cause }
+    );
+  }
+}

--- a/src/load-json-mask.ts
+++ b/src/load-json-mask.ts
@@ -1,0 +1,24 @@
+// ESM-build loader for the OPTIONAL json-mask peer (only dtoSchemaObj needs
+// it). Loaded lazily at first use so consumers of the finders/fragments never
+// need json-mask installed. The CJS build uses load-json-mask-cjs.cts instead
+// (tshy dialect switching).
+import { createRequire } from 'node:module';
+
+export type JsonMaskFn = (obj: any, maskConfig: string) => any;
+
+export function loadJsonMask(): JsonMaskFn {
+  try {
+    // The CJS build swaps in load-json-mask-cjs.cts but still TYPECHECKS this
+    // file, so import.meta needs @ts-ignore there while being error-free in
+    // the ESM pass (which is why it can't be @ts-expect-error).
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const requireFromHere = createRequire(import.meta.url);
+    return requireFromHere('json-mask');
+  } catch (cause) {
+    throw new Error(
+      'dtoSchemaObj requires the optional peer dependency "json-mask" — install it to use schema masking.',
+      { cause }
+    );
+  }
+}

--- a/src/mongoose.ts
+++ b/src/mongoose.ts
@@ -14,7 +14,7 @@ import {
   SanitizeInputs,
 } from './lifecycle-functions.js';
 import { JsonMaskFn, loadJsonMask } from './load-json-mask.js';
-import { Constructor } from './types.js';
+import { Constructor, NestedPathReq } from './types.js';
 
 let jsonMaskFn: JsonMaskFn | undefined;
 
@@ -74,12 +74,9 @@ function readCtxPath(context: any, path: string) {
     .reduce((acc, segment) => (acc == null ? acc : acc[segment]), context);
 }
 
-// Derives the nested context requirement from a ctxRef dot path:
+// The nested context requirement derived from a ctxRef dot path:
 // "inputs.body.user" -> { inputs: { body: { user: unknown } } }.
-export type CtxRefReq<TPath extends string> =
-  TPath extends `${infer THead}.${infer TRest}`
-    ? { [K in THead]: CtxRefReq<TRest> }
-    : { [K in TPath]: unknown };
+export type CtxRefReq<TPath extends string> = NestedPathReq<TPath>;
 
 type UnionToIntersection<U> = (
   U extends any ? (arg: U) => void : never

--- a/src/mongoose.ts
+++ b/src/mongoose.ts
@@ -1,3 +1,10 @@
+// Everyday loader fragments (LoadManyTo & friends) are typed against
+// mongoose's OWN Model/HydratedDocument generics: structural inference from
+// mongoose's overloaded Query/lean machinery resolves to `unknown`, so
+// type-only imports are the deliberate trade-off. They erase at runtime —
+// mongoose stays an optional peer — but consumers of 'hipthrusts/mongoose'
+// need mongoose installed to typecheck (they always did in practice).
+import type { HydratedDocument, Model, SortOrder, Types } from 'mongoose';
 import { HipBadInputs, HipNotFound } from './errors.js';
 import { SanitizeInputsSlices } from './index.js';
 import {
@@ -6,9 +13,10 @@ import {
   RedactResponse,
   SanitizeInputs,
 } from './lifecycle-functions.js';
+import { JsonMaskFn, loadJsonMask } from './load-json-mask.js';
 import { Constructor } from './types.js';
 
-import mask from 'json-mask';
+let jsonMaskFn: JsonMaskFn | undefined;
 
 interface ModelWithFindById<TInstance = any> {
   findById(id: string): { exec(): Promise<TInstance> };
@@ -19,7 +27,7 @@ interface ModelWithFindOne<TInstance = any> {
 }
 
 interface ModelWithFind<TInstance = any> {
-  find(filter: any): { exec(): Promise<TInstance[]> };
+  find(filter: any, projection?: any): { exec(): Promise<TInstance[]> };
 }
 
 // The context contribution/requirement for tenant-scoped list endpoints: some
@@ -28,6 +36,391 @@ interface ModelWithFind<TInstance = any> {
 // the scope is a compile error instead of a cross-tenant data leak.
 export interface HasQueryScope {
   queryScope: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// ctxRef: declarative context-path references for loader filter/id specs.
+// ---------------------------------------------------------------------------
+
+// Symbol.for() so the marker survives dual-package (ESM+CJS) loading; the
+// unique-symbol assertion lets it be used as a literal key in types.
+const CTX_REF: unique symbol = Symbol.for('hipthrusts.ctxRef') as never;
+
+export interface CtxRef<TPath extends string = string> {
+  [CTX_REF]: true;
+  path: TPath;
+}
+
+// Declares "read this value from the lifecycle context at request time" in a
+// loader spec: `LoadOneTo(User, 'user', { _id: ctxRef('inputs.body.user') })`.
+// The context REQUIREMENT is derived from the path string, so deps-met still
+// enforces that an earlier stage provides `inputs.body.user` — with zero
+// hand-written context annotations at the call site.
+export function ctxRef<TPath extends string>(path: TPath): CtxRef<TPath> {
+  return { [CTX_REF]: true, path } as CtxRef<TPath>;
+}
+
+function isCtxRef(value: unknown): value is CtxRef {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Record<PropertyKey, unknown>)[CTX_REF] === true
+  );
+}
+
+function readCtxPath(context: any, path: string) {
+  return path
+    .split('.')
+    .reduce((acc, segment) => (acc == null ? acc : acc[segment]), context);
+}
+
+// Derives the nested context requirement from a ctxRef dot path:
+// "inputs.body.user" -> { inputs: { body: { user: unknown } } }.
+export type CtxRefReq<TPath extends string> =
+  TPath extends `${infer THead}.${infer TRest}`
+    ? { [K in THead]: CtxRefReq<TRest> }
+    : { [K in TPath]: unknown };
+
+type UnionToIntersection<U> = (
+  U extends any ? (arg: U) => void : never
+) extends (arg: infer I) => void
+  ? I
+  : never;
+
+// The combined context requirement of every ctxRef in a filter spec; literal
+// (non-ref) values contribute nothing.
+type SpecReq<TSpec> =
+  UnionToIntersection<
+    {
+      [K in keyof TSpec]: TSpec[K] extends CtxRef<infer TPath>
+        ? CtxRefReq<TPath>
+        : never;
+    }[keyof TSpec]
+  > extends infer TReq
+    ? [TReq] extends [never]
+      ? {}
+      : TReq
+    : never;
+
+// A loader filter spec: field -> ctxRef (resolved per request, $eq-wrapped) or
+// a literal value (developer-authored, passed through verbatim — literals are
+// the escape hatch for operator filters like `{ status: { $in: [...] } }`).
+type FilterSpec = Record<string, unknown>;
+
+// ctxRef-resolved values get $eq-wrapped so user-influenced context values
+// can't smuggle query operators (NoSQL injection hygiene by default), and
+// undefined entries are pruned. Literals pass through verbatim.
+function resolveFilterSpec(
+  spec: FilterSpec | undefined,
+  context: any
+): Record<string, unknown> {
+  const filter: Record<string, unknown> = {};
+  if (!spec) {
+    return filter;
+  }
+  for (const field of Object.keys(spec)) {
+    const value = spec[field];
+    if (isCtxRef(value)) {
+      const resolved = readCtxPath(context, value.path);
+      if (resolved === undefined) {
+        continue;
+      }
+      filter[field] = { $eq: resolved };
+    } else if (value !== undefined) {
+      filter[field] = value;
+    }
+  }
+  return filter;
+}
+
+function resolveIdSpec(
+  idSpec: CtxRef | ((context: any) => unknown),
+  context: any
+) {
+  const id = isCtxRef(idSpec)
+    ? readCtxPath(context, idSpec.path)
+    : idSpec(context);
+  if (id === null || id === undefined || !id.toString()) {
+    throw new HipBadInputs('Missing dependent resource ID');
+  }
+  // A plain object/array here is either a bug or an operator-smuggling
+  // attempt (`{"$ne": null}` as an id); ObjectId instances pass fine.
+  if (
+    typeof id === 'object' &&
+    (Array.isArray(id) || (id as object).constructor === Object)
+  ) {
+    throw new HipBadInputs('Invalid dependent resource ID');
+  }
+  return id;
+}
+
+// Lean reads type as TRaw & { _id } so a downstream stage declaring `_id`
+// passes deps-met.
+export type LeanDocOf<TRaw> = TRaw & { _id: Types.ObjectId };
+
+// ---------------------------------------------------------------------------
+// Everyday loader fragments. All PascalCase + stage-prefixed, matching the
+// core fragment-factory convention.
+// ---------------------------------------------------------------------------
+
+/** LoadResources fragment: `Model.find(spec).lean()` -> ctx[key]: Lean<TRaw>[] */
+export function LoadManyTo<
+  TRaw,
+  TKey extends string,
+  TSpec extends FilterSpec = {},
+>(
+  Model: Model<TRaw>,
+  key: TKey,
+  filterSpec?: TSpec
+): {
+  loadResources: (
+    context: SpecReq<TSpec>
+  ) => Promise<Record<TKey, LeanDocOf<TRaw>[]>>;
+};
+export function LoadManyTo<TRaw, TKey extends string, TCtx extends object>(
+  Model: Model<TRaw>,
+  key: TKey,
+  filterSelector: (context: TCtx) => Record<string, unknown>
+): {
+  loadResources: (context: TCtx) => Promise<Record<TKey, LeanDocOf<TRaw>[]>>;
+};
+export function LoadManyTo(
+  Model: any,
+  key: string,
+  filterSpec?: FilterSpec | ((context: any) => Record<string, unknown>)
+) {
+  return LoadResources(async (context: object) => {
+    const filter =
+      typeof filterSpec === 'function'
+        ? filterSpec(context)
+        : resolveFilterSpec(filterSpec, context);
+    return { [key]: await Model.find(filter).lean().exec() };
+  });
+}
+
+/** LoadResources fragment: `Model.findOne(spec).lean()` -> ctx[key]: Lean<TRaw> | null */
+export function LoadOneTo<
+  TRaw,
+  TKey extends string,
+  TSpec extends FilterSpec = {},
+>(
+  Model: Model<TRaw>,
+  key: TKey,
+  filterSpec?: TSpec
+): {
+  loadResources: (
+    context: SpecReq<TSpec>
+  ) => Promise<Record<TKey, LeanDocOf<TRaw> | null>>;
+};
+export function LoadOneTo<TRaw, TKey extends string, TCtx extends object>(
+  Model: Model<TRaw>,
+  key: TKey,
+  filterSelector: (context: TCtx) => Record<string, unknown>
+): {
+  loadResources: (
+    context: TCtx
+  ) => Promise<Record<TKey, LeanDocOf<TRaw> | null>>;
+};
+export function LoadOneTo(
+  Model: any,
+  key: string,
+  filterSpec?: FilterSpec | ((context: any) => Record<string, unknown>)
+) {
+  return LoadResources(async (context: object) => {
+    const filter =
+      typeof filterSpec === 'function'
+        ? filterSpec(context)
+        : resolveFilterSpec(filterSpec, context);
+    return { [key]: await Model.findOne(filter).lean().exec() };
+  });
+}
+
+/**
+ * LoadResources fragment: `Model.findById(id).lean()`, throwing HipNotFound
+ * when missing -> ctx[key]: Lean<TRaw>. 404-on-missing is the SHORT pattern.
+ */
+export function LoadByIdRequiredTo<
+  TRaw,
+  TKey extends string,
+  TPath extends string,
+>(
+  Model: Model<TRaw>,
+  key: TKey,
+  idRef: CtxRef<TPath>,
+  notFoundMessage?: string
+): {
+  loadResources: (
+    context: CtxRefReq<TPath>
+  ) => Promise<Record<TKey, LeanDocOf<TRaw>>>;
+};
+export function LoadByIdRequiredTo<
+  TRaw,
+  TKey extends string,
+  TCtx extends object,
+>(
+  Model: Model<TRaw>,
+  key: TKey,
+  idSelector: (context: TCtx) => unknown,
+  notFoundMessage?: string
+): {
+  loadResources: (context: TCtx) => Promise<Record<TKey, LeanDocOf<TRaw>>>;
+};
+export function LoadByIdRequiredTo(
+  Model: any,
+  key: string,
+  idSpec: CtxRef | ((context: any) => unknown),
+  notFoundMessage?: string
+) {
+  return LoadResources(async (context: object) => {
+    const id = resolveIdSpec(idSpec, context);
+    const doc = await Model.findById(id).lean().exec();
+    if (!doc) {
+      throw new HipNotFound(notFoundMessage ?? 'Resource not found');
+    }
+    return { [key]: doc };
+  });
+}
+
+/**
+ * LoadResources fragment: `Model.findById(id)` HYDRATED (for update flows that
+ * `.set()`/`.save()`), throwing HipNotFound when missing
+ * -> ctx[key]: HydratedDocument<TRaw>.
+ */
+export function LoadDocByIdRequiredTo<
+  TRaw,
+  TKey extends string,
+  TPath extends string,
+>(
+  Model: Model<TRaw>,
+  key: TKey,
+  idRef: CtxRef<TPath>,
+  notFoundMessage?: string
+): {
+  loadResources: (
+    context: CtxRefReq<TPath>
+  ) => Promise<Record<TKey, HydratedDocument<TRaw>>>;
+};
+export function LoadDocByIdRequiredTo<
+  TRaw,
+  TKey extends string,
+  TCtx extends object,
+>(
+  Model: Model<TRaw>,
+  key: TKey,
+  idSelector: (context: TCtx) => unknown,
+  notFoundMessage?: string
+): {
+  loadResources: (
+    context: TCtx
+  ) => Promise<Record<TKey, HydratedDocument<TRaw>>>;
+};
+export function LoadDocByIdRequiredTo(
+  Model: any,
+  key: string,
+  idSpec: CtxRef | ((context: any) => unknown),
+  notFoundMessage?: string
+) {
+  return LoadResources(async (context: object) => {
+    const id = resolveIdSpec(idSpec, context);
+    const doc = await Model.findById(id).exec();
+    if (!doc) {
+      throw new HipNotFound(notFoundMessage ?? 'Resource not found');
+    }
+    return { [key]: doc };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Scoped finders (tenant-scoped list endpoints). PascalCase is the canonical
+// naming (matching every other fragment factory); the camelCase names on
+// htMongooseFactory remain as aliases.
+// ---------------------------------------------------------------------------
+
+// Query options for scoped finders. `queryScope` stays a type-REQUIRED
+// context key exactly as before — these only shape the query itself.
+export interface ScopedQueryOptions {
+  sort?: string | Record<string, SortOrder>;
+  limit?: number;
+  skip?: number;
+  projection?: string | Record<string, unknown>;
+  lean?: boolean;
+}
+
+export interface FindScopedOptions<
+  TKey extends string = 'scopedDocs',
+> extends ScopedQueryOptions {
+  docsKey?: TKey;
+}
+
+function execScopedQuery(
+  Model: ModelWithFind,
+  filter: Record<string, unknown>,
+  options: ScopedQueryOptions
+) {
+  let query: any =
+    options.projection !== undefined
+      ? Model.find(filter, options.projection)
+      : Model.find(filter);
+  if (options.sort !== undefined) {
+    query = query.sort(options.sort);
+  }
+  if (options.skip !== undefined) {
+    query = query.skip(options.skip);
+  }
+  if (options.limit !== undefined) {
+    query = query.limit(options.limit);
+  }
+  if (options.lean) {
+    query = query.lean();
+  }
+  return query.exec();
+}
+
+// LoadResources fragment: fetches Model.find with the composed filter
+// `{ ...ctx.queryScope, ...extraFilter }` and stores the rows under
+// `docsKey`. `queryScope` is REQUIRED in the context type, so the deps-met
+// machinery forces some earlier fragment (e.g. a LoadResources contributing
+// the caller's tenant filter) to provide it — authorization-as-query-scope
+// by construction.
+export function LoadScopedTo<TKey extends string>(
+  Model: ModelWithFind,
+  docsKey: TKey,
+  extraFilter?: object,
+  options: ScopedQueryOptions = {}
+) {
+  return LoadResources(async (context: HasQueryScope) => {
+    return {
+      [docsKey]: await execScopedQuery(
+        Model,
+        { ...context.queryScope, ...(extraFilter || {}) },
+        options
+      ),
+    } as Record<TKey, any[]>;
+  });
+}
+
+// The plain list endpoint in one fragment: LoadScopedTo on the load stage
+// (so the rows sit in context for finalAuthorize / redactResponse /
+// downstream execute stages) plus a trivial execute that returns them.
+// Fetching lives on the LOAD stage — piping your own execute after this one
+// overrides the response without re-running or wasting the query.
+// The third parameter takes an options bag ({ sort, limit, skip, projection,
+// lean, docsKey }); a bare string is accepted as the docs key for
+// backward compatibility.
+export function FindScoped<TKey extends string = 'scopedDocs'>(
+  Model: ModelWithFind,
+  extraFilter?: object,
+  docsKeyOrOptions?: TKey | FindScopedOptions<TKey>
+) {
+  const options: FindScopedOptions<TKey> =
+    typeof docsKeyOrOptions === 'string'
+      ? { docsKey: docsKeyOrOptions }
+      : (docsKeyOrOptions ?? {});
+  const key = (options.docsKey ?? 'scopedDocs') as TKey;
+  return {
+    ...LoadScopedTo(Model, key, extraFilter, options),
+    ...Execute((context: Record<TKey, any[]>) => context[key]),
+  };
 }
 
 interface HasValidateSync {
@@ -89,7 +482,12 @@ export function htMongooseFactory(mongoose: any) {
   }
 
   function dtoSchemaObj(schemaConfigObject: any, maskConfig: string) {
-    return deepWipeDefault(mask(schemaConfigObject, maskConfig));
+    // json-mask is loaded lazily so consumers using only the finders/loaders
+    // don't need the optional peer installed.
+    if (!jsonMaskFn) {
+      jsonMaskFn = loadJsonMask();
+    }
+    return deepWipeDefault(jsonMaskFn(schemaConfigObject, maskConfig));
   }
 
   type DocumentFactory<T> = (
@@ -174,44 +572,6 @@ export function htMongooseFactory(mongoose: any) {
     return SanitizeInputsSlices(sanitizers);
   }
 
-  // LoadResources fragment: fetches Model.find with the composed filter
-  // `{ ...ctx.queryScope, ...extraFilter }` and stores the rows under
-  // `docsKey`. `queryScope` is REQUIRED in the context type, so the deps-met
-  // machinery forces some earlier fragment (e.g. a LoadResources contributing
-  // the caller's tenant filter) to provide it — authorization-as-query-scope
-  // by construction.
-  function loadScopedTo<TKey extends string>(
-    Model: ModelWithFind,
-    docsKey: TKey,
-    extraFilter?: object
-  ) {
-    return LoadResources(async (context: HasQueryScope) => {
-      return {
-        [docsKey]: await Model.find({
-          ...context.queryScope,
-          ...(extraFilter || {}),
-        }).exec(),
-      } as Record<TKey, any[]>;
-    });
-  }
-
-  // The plain list endpoint in one fragment: loadScopedTo on the load stage
-  // (so the rows sit in context for finalAuthorize / redactResponse /
-  // downstream execute stages) plus a trivial execute that returns them.
-  // Fetching lives on the LOAD stage — piping your own execute after this one
-  // overrides the response without re-running or wasting the query.
-  function findScoped<TKey extends string = 'scopedDocs'>(
-    Model: ModelWithFind,
-    extraFilter?: object,
-    docsKey?: TKey
-  ) {
-    const key = (docsKey ?? 'scopedDocs') as TKey;
-    return {
-      ...loadScopedTo(Model, key, extraFilter),
-      ...Execute((context: Record<TKey, any[]>) => context[key]),
-    };
-  }
-
   function SaveOnDocumentFrom(propertyKeyOfDocument: string) {
     return Execute(async (context: any) => {
       if (context[propertyKeyOfDocument]) {
@@ -286,8 +646,19 @@ export function htMongooseFactory(mongoose: any) {
     dtoSchemaObj,
     findByIdRequired,
     findOneByRequired,
-    findScoped,
-    loadScopedTo,
+    // Everyday loader fragments (also exported at module level — none of them
+    // need the mongoose instance; they're on the factory for discoverability).
+    ctxRef,
+    LoadManyTo,
+    LoadOneTo,
+    LoadByIdRequiredTo,
+    LoadDocByIdRequiredTo,
+    // Scoped finders. PascalCase is canonical; the camelCase names are
+    // backward-compatible aliases.
+    FindScoped,
+    LoadScopedTo,
+    findScoped: FindScoped,
+    loadScopedTo: LoadScopedTo,
     stripIdTransform,
   };
 }

--- a/src/next.ts
+++ b/src/next.ts
@@ -155,7 +155,12 @@ export function toNextHandler<
         // final context, via Next's `after()` (runs once the response is
         // sent). Failed requests never fire it.
         const runAfterResponse = () =>
-          safeInvokeAfterResponse(options.afterResponse, context);
+          safeInvokeAfterResponse(
+            options.afterResponse,
+            context,
+            options.onError,
+            raw
+          );
         try {
           const { after } = await import('next/server.js');
           after(runAfterResponse);
@@ -191,5 +196,25 @@ export function toNextHandler<
         { status: 500 }
       );
     }
+  };
+}
+
+// Adapter preset factory: bakes shared options (gatherContext, onError,
+// afterResponse, ...) into a reusable handler converter so routes don't
+// repeat them on every toNextHandler call:
+//   export const toAppHandler = makeNextHandlerFactory({ gatherContext });
+// Per-call options merge OVER the defaults.
+export function makeNextHandlerFactory(defaults: HipNextHandlerOptions) {
+  return function toNextHandlerWithDefaults<
+    TConf extends OptionalStagesShape &
+      HasRequiredStages &
+      PreAuthorizeDepsMet<TConf> &
+      LoadResourcesDepsMet<TConf> &
+      FinalAuthorizeDepsMet<TConf> &
+      ExecuteDepsMet<TConf> &
+      RedactResponseDepsMet<TConf> &
+      HasResponseMeta,
+  >(handlingStrategy: TConf, options: HipNextHandlerOptions = {}) {
+    return toNextHandler(handlingStrategy, { ...defaults, ...options });
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,15 @@ export type SanitizedOnly<T> = T extends object
   ? Omit<T, typeof UNSAFE_SLICES>
   : T;
 
+// Derives a nested requirement type from a dot path — the "key of a key"
+// indication used by selector composers (RedactResponseByKey) and the
+// mongoose loaders' ctxRef specs:
+// 'inputs.body.user' -> { inputs: { body: { user: unknown } } }
+export type NestedPathReq<TPath extends string> =
+  TPath extends `${infer THead}.${infer TRest}`
+    ? { [K in THead]: NestedPathReq<TRest> }
+    : { [K in TPath]: unknown };
+
 export type PromiseOrSync<T> = Promise<T> | T;
 export type PromiseResolveOrSync<T> = T extends Promise<infer U> ? U : T;
 

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -66,48 +66,6 @@ export function htZodFactory() {
     });
   }
 
-  // Role-dependent redaction: picks the wire schema by a context-derived key
-  // (a boolean flag or a role string), so "members see {names}, admins see
-  // {names, emails}" is one declarative fragment instead of a hand-branching
-  // redactor:
-  //   RedactResponseByRoleWithZod((ctx) => ctx.canSeeEmails, {
-  //     true: adminWireSchema,
-  //     false: memberWireSchema,
-  //   })
-  // The selector's context requirement participates in deps-met like any
-  // two-parameter redactor's, so an un-contributed key is a compile error.
-  function RedactResponseByRoleWithZod<
-    TCtx extends object,
-    TKey extends string | number | boolean,
-    TSchemas extends Record<`${TKey}`, z.ZodType<any, any, any>>,
-  >(selector: (context: TCtx) => TKey, schemas: TSchemas) {
-    // Built as a literal (not via RedactResponse) so the context parameter can
-    // stay REQUIRED and precisely typed — that is what makes the selector's
-    // context requirement participate in deps-met.
-    return {
-      redactResponse: (
-        unsafeResponse: any,
-        context: TCtx
-      ): z.output<TSchemas[`${TKey}`]> => {
-        const key = String(selector(context)) as `${TKey}`;
-        const schema: z.ZodType<any, any, any> | undefined = schemas[key];
-        if (!schema) {
-          throw new HipInternal(
-            `No response schema registered for role key "${key}"`
-          );
-        }
-        const parseResult = schema.safeParse(unsafeResponse);
-        if (!parseResult.success) {
-          throw new HipInternal(
-            'Response validation failed',
-            parseResult.error
-          );
-        }
-        return parseResult.data;
-      },
-    };
-  }
-
   function PojoToValidated<
     TPojoKey extends string,
     TSchema extends z.ZodType<any, any, any>,
@@ -128,7 +86,6 @@ export function htZodFactory() {
     SanitizeInputsWithZod,
     SanitizeInputsSlicesWithZod,
     RedactResponseWithZod,
-    RedactResponseByRoleWithZod,
     PojoToValidated,
     stripIdTransform,
   };

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -66,6 +66,48 @@ export function htZodFactory() {
     });
   }
 
+  // Role-dependent redaction: picks the wire schema by a context-derived key
+  // (a boolean flag or a role string), so "members see {names}, admins see
+  // {names, emails}" is one declarative fragment instead of a hand-branching
+  // redactor:
+  //   RedactResponseByRoleWithZod((ctx) => ctx.canSeeEmails, {
+  //     true: adminWireSchema,
+  //     false: memberWireSchema,
+  //   })
+  // The selector's context requirement participates in deps-met like any
+  // two-parameter redactor's, so an un-contributed key is a compile error.
+  function RedactResponseByRoleWithZod<
+    TCtx extends object,
+    TKey extends string | number | boolean,
+    TSchemas extends Record<`${TKey}`, z.ZodType<any, any, any>>,
+  >(selector: (context: TCtx) => TKey, schemas: TSchemas) {
+    // Built as a literal (not via RedactResponse) so the context parameter can
+    // stay REQUIRED and precisely typed — that is what makes the selector's
+    // context requirement participate in deps-met.
+    return {
+      redactResponse: (
+        unsafeResponse: any,
+        context: TCtx
+      ): z.output<TSchemas[`${TKey}`]> => {
+        const key = String(selector(context)) as `${TKey}`;
+        const schema: z.ZodType<any, any, any> | undefined = schemas[key];
+        if (!schema) {
+          throw new HipInternal(
+            `No response schema registered for role key "${key}"`
+          );
+        }
+        const parseResult = schema.safeParse(unsafeResponse);
+        if (!parseResult.success) {
+          throw new HipInternal(
+            'Response validation failed',
+            parseResult.error
+          );
+        }
+        return parseResult.data;
+      },
+    };
+  }
+
   function PojoToValidated<
     TPojoKey extends string,
     TSchema extends z.ZodType<any, any, any>,
@@ -86,6 +128,7 @@ export function htZodFactory() {
     SanitizeInputsWithZod,
     SanitizeInputsSlicesWithZod,
     RedactResponseWithZod,
+    RedactResponseByRoleWithZod,
     PojoToValidated,
     stripIdTransform,
   };

--- a/test/finish-pipe.test-d.ts
+++ b/test/finish-pipe.test-d.ts
@@ -1,0 +1,118 @@
+// Type-level tests for finishPipe: the trailing handler's stage callbacks get
+// their context types inferred from the pipe (zero annotations), phantom
+// context keys are compile errors, and pipe-internal deps-met requirements
+// still surface as HipDepNotMet through the adapters.
+import mongoose from 'mongoose';
+import { describe, expectTypeOf, it } from 'vitest';
+import { finishPipe, HTPipe, SanitizeInputsSlices } from '../src/index.js';
+import { htMongooseFactory } from '../src/mongoose.js';
+import { toNextHandler } from '../src/next.js';
+
+const AuthedPipe = HTPipe(
+  {
+    extractAmbient: (raw: any) => ({
+      principal: { id: String(raw.userId), roles: [] as string[] },
+    }),
+  },
+  SanitizeInputsSlices({ params: (p: any) => ({ id: String(p.id) }) }),
+  {
+    preAuthorize: (ctx: {
+      ambient: { principal: { id: string; roles: string[] } };
+    }) => ({ principal: ctx.ambient.principal }),
+  }
+);
+
+describe('finishPipe trailing-handler inference', () => {
+  it('infers every trailing stage ctx from the pipe with zero annotations', () => {
+    const finished = finishPipe(AuthedPipe, {
+      loadResources: (ctx) => {
+        expectTypeOf(ctx.principal).toEqualTypeOf<{
+          id: string;
+          roles: string[];
+        }>();
+        // UNSAFE_SLICES / index carriers are stripped from the computed inputs.
+        expectTypeOf(ctx.inputs).toEqualTypeOf<{ params: { id: string } }>();
+        return { doc: { id: ctx.inputs.params.id, ownerId: 'o1' } };
+      },
+      finalAuthorize: (ctx) => {
+        expectTypeOf(ctx.doc).toEqualTypeOf<{ id: string; ownerId: string }>();
+        return ctx.doc.ownerId === ctx.principal.id && { canWrite: true };
+      },
+      execute: (ctx) => {
+        expectTypeOf(ctx.canWrite).toEqualTypeOf<boolean>();
+        return { id: ctx.doc.id, wrote: ctx.canWrite };
+      },
+      redactResponse: (unsafe, ctx) => {
+        expectTypeOf(unsafe).toEqualTypeOf<{ id: string; wrote: boolean }>();
+        expectTypeOf(ctx.principal.id).toEqualTypeOf<string>();
+        return unsafe;
+      },
+    });
+    const handler = toNextHandler(finished);
+    expectTypeOf(handler).toBeFunction();
+  });
+
+  it('an async trailing loadResources contributes its awaited return', () => {
+    const finished = finishPipe(AuthedPipe, {
+      loadResources: async (ctx) => ({ doc: { id: ctx.inputs.params.id } }),
+      finalAuthorize: (ctx) => {
+        expectTypeOf(ctx.doc).toEqualTypeOf<{ id: string }>();
+        return !!ctx.doc;
+      },
+      execute: (ctx) => ctx.doc,
+      redactResponse: (unsafe) => unsafe,
+    });
+    expectTypeOf(toNextHandler(finished)).toBeFunction();
+  });
+
+  it('consuming a phantom ctx key is a compile error', () => {
+    finishPipe(AuthedPipe, {
+      finalAuthorize: (ctx) => {
+        // @ts-expect-error - nothing contributes `phantom` to the context
+        return !!ctx.phantom;
+      },
+      execute: () => ({ ok: true }),
+      redactResponse: (unsafe) => unsafe,
+    });
+  });
+
+  it('extraction/sanitization stages are rejected in the trailing handler', () => {
+    finishPipe(AuthedPipe, {
+      // @ts-expect-error - sanitize stages belong in the pipe, not the handler
+      sanitizeInputs: (unsafe: any) => unsafe,
+      execute: () => ({ ok: true }),
+      redactResponse: (unsafe) => unsafe,
+    });
+  });
+});
+
+describe('finishPipe preserves pipe-internal HipDepNotMet enforcement', () => {
+  const listModel = {
+    find: (_filter: any) => ({ exec: async () => [] as any[] }),
+  };
+  const ScopedPipe = HTPipe(
+    SanitizeInputsSlices({ params: (p: any) => ({ id: String(p.id) }) }),
+    { preAuthorize: () => true },
+    htMongooseFactory(mongoose).findScoped(listModel)
+  );
+
+  it('a handler contributing queryScope compiles', () => {
+    const finished = finishPipe(ScopedPipe, {
+      preAuthorize: (ctx) => ({
+        queryScope: { tenant: ctx.inputs.params.id } as Record<string, unknown>,
+      }),
+      finalAuthorize: () => true,
+      redactResponse: (unsafe) => unsafe,
+    });
+    expectTypeOf(toNextHandler(finished)).toBeFunction();
+  });
+
+  it('a handler NOT contributing queryScope fails at the adapter boundary', () => {
+    const finished = finishPipe(ScopedPipe, {
+      finalAuthorize: () => true,
+      redactResponse: (unsafe) => unsafe,
+    });
+    // @ts-expect-error - the pipe's findScoped requires `queryScope`
+    toNextHandler(finished);
+  });
+});

--- a/test/finish-pipe.test.ts
+++ b/test/finish-pipe.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  executeHipthrustable,
+  finishPipe,
+  HipForbidden,
+  HTPipe,
+  SanitizeInputsSlices,
+  withDefaultImplementations,
+} from '../src/index.js';
+
+const BasePipe = HTPipe(
+  { extractAmbient: (raw: any) => ({ userId: String(raw.userId) }) },
+  SanitizeInputsSlices({ params: (p: any) => ({ id: String(p.id) }) }),
+  {
+    preAuthorize: (ctx: { ambient: { userId: string } }) => ({
+      principal: ctx.ambient.userId,
+    }),
+  },
+  { loadResources: () => ({ fromPipe: 'pipe-loaded' }) }
+);
+
+describe('finishPipe runtime (plain HTPipe composition)', () => {
+  it('runs pipe stages first, handler stages after, merging contributions', async () => {
+    const finished = finishPipe(BasePipe, {
+      loadResources: (ctx) => ({ doc: `${ctx.fromPipe}:doc` }),
+      finalAuthorize: (ctx) => ctx.principal === 'u1',
+      execute: (ctx) => ({
+        id: ctx.inputs.params.id,
+        doc: ctx.doc,
+        by: ctx.principal,
+      }),
+      redactResponse: (unsafe) => ({ id: unsafe.id, doc: unsafe.doc }),
+      responseMeta: { status: 201 },
+    });
+
+    expect(finished.responseMeta).toEqual({ status: 201 });
+
+    const { response } = await executeHipthrustable(
+      withDefaultImplementations(finished as any) as any,
+      { userId: 'u1', params: { id: '42' } }
+    );
+    expect(response).toEqual({ id: '42', doc: 'pipe-loaded:doc' });
+  });
+
+  it('handler finalAuthorize denial is a HipForbidden like any piped stage', async () => {
+    const finished = finishPipe(BasePipe, {
+      finalAuthorize: (ctx) => ctx.principal === 'someone-else',
+      execute: () => ({ ok: true }),
+      redactResponse: (unsafe) => unsafe,
+    });
+    await expect(
+      executeHipthrustable(withDefaultImplementations(finished as any) as any, {
+        userId: 'u1',
+        params: { id: '42' },
+      })
+    ).rejects.toThrow(HipForbidden);
+  });
+
+  it('chains the handler redactor after the pipe redactor', async () => {
+    const pipeWithRedact = HTPipe(BasePipe, {
+      redactResponse: (unsafe: any) => ({ ...unsafe, pipeRedacted: true }),
+    });
+    const finished = finishPipe(pipeWithRedact, {
+      finalAuthorize: () => true,
+      execute: () => ({ secret: 's', name: 'n' }),
+      redactResponse: (unsafe: any) => ({
+        name: unsafe.name,
+        sawPipeRedaction: unsafe.pipeRedacted === true,
+      }),
+    });
+    const { response } = await executeHipthrustable(
+      withDefaultImplementations(finished as any) as any,
+      { userId: 'u1', params: { id: '1' } }
+    );
+    expect(response).toEqual({ name: 'n', sawPipeRedaction: true });
+  });
+});

--- a/test/mongoose-loaders.test-d.ts
+++ b/test/mongoose-loaders.test-d.ts
@@ -1,0 +1,120 @@
+// Type-level tests for the everyday mongoose loader fragments: ctxRef paths
+// derive real deps-met requirements (zero hand-written ctx annotations), and
+// lean reads carry `_id`.
+import type { Model, Types } from 'mongoose';
+import { describe, expectTypeOf, it } from 'vitest';
+import { HTPipe, SanitizeInputsSlices } from '../src/index.js';
+import {
+  ctxRef,
+  LoadByIdRequiredTo,
+  LoadDocByIdRequiredTo,
+  LoadManyTo,
+  LoadOneTo,
+} from '../src/mongoose.js';
+import { toNextHandler } from '../src/next.js';
+
+interface User {
+  email: string;
+  name: string;
+}
+const UserModel = {} as unknown as Model<User>;
+
+const requiredTail = {
+  preAuthorize: () => true,
+  finalAuthorize: () => true,
+  redactResponse: (u: any) => u,
+};
+
+describe('ctxRef-derived requirements', () => {
+  it('compiles when an earlier stage provides the referenced path', () => {
+    const handler = toNextHandler(
+      HTPipe(
+        SanitizeInputsSlices({ body: (b: any) => ({ user: String(b.user) }) }),
+        LoadOneTo(UserModel, 'user', { _id: ctxRef('inputs.body.user') }),
+        {
+          ...requiredTail,
+          execute: (ctx: {
+            user: (User & { _id: Types.ObjectId }) | null;
+          }) => ({ email: ctx.user?.email }),
+        }
+      )
+    );
+    expectTypeOf(handler).toBeFunction();
+  });
+
+  it('fails deps-met when nothing provides the referenced path', () => {
+    // Only `params` is sanitized; the spec references `inputs.body.user`.
+    const conf = {
+      sanitizeInputs: (i: any) => ({ params: { id: String(i.params.id) } }),
+      ...requiredTail,
+      ...LoadOneTo(UserModel, 'user', { _id: ctxRef('inputs.body.user') }),
+      execute: (ctx: { user: (User & { _id: Types.ObjectId }) | null }) => ({
+        email: ctx.user?.email,
+      }),
+    };
+    // @ts-expect-error - no provider for inputs.body.user
+    toNextHandler(conf);
+  });
+
+  it('literal (non-ref) spec values contribute no requirements', () => {
+    const frag = LoadManyTo(UserModel, 'users', { name: 'fixed' });
+    // Callable with an empty context: the literal spec demanded nothing.
+    const out = frag.loadResources({});
+    expectTypeOf(out).resolves.toEqualTypeOf<
+      Record<'users', (User & { _id: Types.ObjectId })[]>
+    >();
+  });
+
+  it('the selector-function overload keeps its declared ctx requirement', () => {
+    const frag = LoadManyTo(UserModel, 'users', (ctx: { tenant: string }) => ({
+      tenant: ctx.tenant,
+    }));
+    expectTypeOf(frag.loadResources)
+      .parameter(0)
+      .toEqualTypeOf<{ tenant: string }>();
+  });
+});
+
+describe('lean and hydrated result typing', () => {
+  it('LoadManyTo types rows as lean docs WITH _id', () => {
+    const frag = LoadManyTo(UserModel, 'users');
+    type Out = Awaited<ReturnType<typeof frag.loadResources>>;
+    expectTypeOf<Out['users'][number]['_id']>().toEqualTypeOf<Types.ObjectId>();
+    expectTypeOf<Out['users'][number]['email']>().toEqualTypeOf<string>();
+  });
+
+  it('LoadOneTo types the row as lean doc or null', () => {
+    const frag = LoadOneTo(UserModel, 'user', {
+      email: ctxRef('inputs.body.email'),
+    });
+    type Out = Awaited<ReturnType<typeof frag.loadResources>>;
+    expectTypeOf<Out['user']>().toEqualTypeOf<
+      (User & { _id: Types.ObjectId }) | null
+    >();
+  });
+
+  it('LoadByIdRequiredTo types the row as a NON-nullable lean doc', () => {
+    const frag = LoadByIdRequiredTo(
+      UserModel,
+      'user',
+      ctxRef('inputs.params.id')
+    );
+    type Out = Awaited<ReturnType<typeof frag.loadResources>>;
+    expectTypeOf<Out['user']['_id']>().toEqualTypeOf<Types.ObjectId>();
+    // The ctxRef path became the fragment's context requirement.
+    expectTypeOf(frag.loadResources)
+      .parameter(0)
+      .toEqualTypeOf<{ inputs: { params: { id: unknown } } }>();
+  });
+
+  it('LoadDocByIdRequiredTo types the row as a hydrated document', () => {
+    const frag = LoadDocByIdRequiredTo(
+      UserModel,
+      'userDoc',
+      ctxRef('inputs.params.id')
+    );
+    type Out = Awaited<ReturnType<typeof frag.loadResources>>;
+    // Hydrated documents carry mongoose instance methods like save().
+    expectTypeOf<Out['userDoc']['save']>().toBeFunction();
+  });
+});

--- a/test/mongoose.test.ts
+++ b/test/mongoose.test.ts
@@ -1,7 +1,15 @@
 import mongoose from 'mongoose';
 import { describe, expect, it } from 'vitest';
 import { HipBadInputs, HipNotFound } from '../src/errors';
-import { htMongooseFactory } from '../src/mongoose';
+import {
+  ctxRef,
+  FindScoped,
+  htMongooseFactory,
+  LoadByIdRequiredTo,
+  LoadDocByIdRequiredTo,
+  LoadManyTo,
+  LoadOneTo,
+} from '../src/mongoose';
 
 // Everything here runs against real mongoose but WITHOUT a database
 // connection: schema construction, document instantiation, and validateSync
@@ -242,5 +250,217 @@ describe('findScoped / loadScopedTo (Finding P2-10)', () => {
       queryScope: { tenant: { $in: ['b'] } },
     });
     expect(out.items.map((r: any) => r.name)).toEqual(['b-one']);
+  });
+});
+
+// A chainable fake query capturing every call, for loader/options assertions.
+function fakeQuery(result: any) {
+  const calls: Record<string, any[]> = {};
+  const query: any = { calls };
+  for (const method of ['sort', 'skip', 'limit', 'lean']) {
+    query[method] = (...args: any[]) => {
+      calls[method] = args;
+      return query;
+    };
+  }
+  query.exec = async () => result;
+  return query;
+}
+
+describe('everyday loaders: ctxRef filter specs', () => {
+  it('LoadOneTo $eq-wraps ctxRef values, passes literals verbatim, prunes undefined', async () => {
+    let seenFilter: any;
+    let lastQuery: any;
+    const model: any = {
+      findOne(filter: any) {
+        seenFilter = filter;
+        lastQuery = fakeQuery({ email: 'a@b.c' });
+        return lastQuery;
+      },
+    };
+    const { loadResources } = LoadOneTo(model, 'user', {
+      _id: ctxRef('inputs.body.user'),
+      status: { $in: ['active', 'invited'] },
+      missing: ctxRef('inputs.body.nope'),
+      alsoMissing: undefined,
+    });
+    const out: any = await loadResources({
+      inputs: { body: { user: 'u1' } },
+    } as any);
+    expect(seenFilter).toEqual({
+      _id: { $eq: 'u1' },
+      status: { $in: ['active', 'invited'] },
+    });
+    expect(lastQuery.calls.lean).toEqual([]);
+    expect(out.user).toEqual({ email: 'a@b.c' });
+  });
+
+  it('LoadManyTo resolves the spec and stores the lean rows', async () => {
+    let seenFilter: any;
+    const rows = [{ name: 'one' }, { name: 'two' }];
+    const model: any = {
+      find(filter: any) {
+        seenFilter = filter;
+        return fakeQuery(rows);
+      },
+    };
+    const { loadResources } = LoadManyTo(model, 'things', {
+      businessGroup: ctxRef('inputs.params.businessGroupId'),
+    });
+    const out: any = await loadResources({
+      inputs: { params: { businessGroupId: 'bg1' } },
+    } as any);
+    expect(seenFilter).toEqual({ businessGroup: { $eq: 'bg1' } });
+    expect(out.things).toBe(rows);
+  });
+
+  it('the selector-function overload passes its computed filter verbatim', async () => {
+    let seenFilter: any;
+    const model: any = {
+      find(filter: any) {
+        seenFilter = filter;
+        return fakeQuery([]);
+      },
+    };
+    const { loadResources } = LoadManyTo(
+      model,
+      'rows',
+      (ctx: { tenantIds: string[] }) => ({ tenant: { $in: ctx.tenantIds } })
+    );
+    await loadResources({ tenantIds: ['a', 'b'] });
+    expect(seenFilter).toEqual({ tenant: { $in: ['a', 'b'] } });
+  });
+});
+
+describe('everyday loaders: required-by-id variants', () => {
+  const found = { name: 'thing' };
+  function modelWithFindById(result: any) {
+    let leanCalled = false;
+    return {
+      leanCalled: () => leanCalled,
+      findById(_id: any) {
+        const query = fakeQuery(result);
+        const origLean = query.lean;
+        query.lean = (...args: any[]) => {
+          leanCalled = true;
+          return origLean(...args);
+        };
+        return query;
+      },
+    } as any;
+  }
+
+  it('LoadByIdRequiredTo loads lean and stores under the key', async () => {
+    const model = modelWithFindById(found);
+    const { loadResources } = LoadByIdRequiredTo(
+      model,
+      'thing',
+      ctxRef('inputs.params.id')
+    );
+    const out: any = await loadResources({
+      inputs: { params: { id: 'x1' } },
+    } as any);
+    expect(out.thing).toBe(found);
+    expect(model.leanCalled()).toBe(true);
+  });
+
+  it('LoadByIdRequiredTo throws HipNotFound (custom message) when missing', async () => {
+    const { loadResources } = LoadByIdRequiredTo(
+      modelWithFindById(null),
+      'thing',
+      ctxRef('inputs.params.id'),
+      'No such thing'
+    );
+    await expect(
+      loadResources({ inputs: { params: { id: 'x1' } } } as any)
+    ).rejects.toThrow(new HipNotFound('No such thing'));
+  });
+
+  it('LoadByIdRequiredTo rejects missing and object-smuggled ids as HipBadInputs', async () => {
+    const { loadResources } = LoadByIdRequiredTo(
+      modelWithFindById(found),
+      'thing',
+      ctxRef('inputs.params.id')
+    );
+    await expect(
+      loadResources({ inputs: { params: {} } } as any)
+    ).rejects.toThrow(HipBadInputs);
+    await expect(
+      loadResources({ inputs: { params: { id: { $ne: null } } } } as any)
+    ).rejects.toThrow(HipBadInputs);
+  });
+
+  it('LoadDocByIdRequiredTo loads HYDRATED (no lean) and 404s when missing', async () => {
+    const model = modelWithFindById(found);
+    const { loadResources } = LoadDocByIdRequiredTo(
+      model,
+      'thingDoc',
+      ctxRef('inputs.params.id')
+    );
+    const out: any = await loadResources({
+      inputs: { params: { id: 'x1' } },
+    } as any);
+    expect(out.thingDoc).toBe(found);
+    expect(model.leanCalled()).toBe(false);
+
+    const emptyModel = modelWithFindById(null);
+    const { loadResources: loadMissing } = LoadDocByIdRequiredTo(
+      emptyModel,
+      'thingDoc',
+      (ctx: any) => ctx.inputs.params.id
+    );
+    await expect(
+      loadMissing({ inputs: { params: { id: 'x1' } } } as any)
+    ).rejects.toThrow(HipNotFound);
+  });
+});
+
+describe('scoped finder query options', () => {
+  it('applies sort/skip/limit/lean and a projection to the scoped query', async () => {
+    let seenFilter: any;
+    let seenProjection: any;
+    let lastQuery: any;
+    const model: any = {
+      find(filter: any, projection?: any) {
+        seenFilter = filter;
+        seenProjection = projection;
+        lastQuery = fakeQuery([{ name: 'row' }]);
+        return lastQuery;
+      },
+    };
+    const frag = FindScoped(
+      model,
+      { archived: false },
+      {
+        docsKey: 'items',
+        sort: { createdAt: -1 },
+        skip: 5,
+        limit: 100,
+        lean: true,
+        projection: { name: 1 },
+      }
+    );
+    const loaded: any = await frag.loadResources({
+      queryScope: { tenant: { $eq: 't1' } },
+    });
+    expect(seenFilter).toEqual({
+      tenant: { $eq: 't1' },
+      archived: false,
+    });
+    expect(seenProjection).toEqual({ name: 1 });
+    expect(lastQuery.calls).toEqual({
+      sort: [{ createdAt: -1 }],
+      skip: [5],
+      limit: [100],
+      lean: [],
+    });
+    expect(frag.execute(loaded)).toEqual([{ name: 'row' }]);
+  });
+
+  it('keeps the bare-string docsKey back-compat form', async () => {
+    const model: any = { find: () => fakeQuery([{ name: 'r' }]) };
+    const frag = FindScoped(model, undefined, 'items');
+    const loaded: any = await frag.loadResources({ queryScope: {} });
+    expect(loaded.items).toEqual([{ name: 'r' }]);
   });
 });

--- a/test/next-adapter.test.ts
+++ b/test/next-adapter.test.ts
@@ -4,7 +4,11 @@ import { z } from 'zod';
 import { HTPipe } from '../src';
 import { HipConflict, HipForbidden, HipRedirect } from '../src/errors';
 import { htZodFactory } from '../src/zod';
-import { defineNextHandler, toNextHandler } from '../src/next';
+import {
+  defineNextHandler,
+  makeNextHandlerFactory,
+  toNextHandler,
+} from '../src/next';
 
 function postReq(url: string, body: any): NextRequest {
   return new NextRequest(url, {
@@ -265,6 +269,108 @@ describe('adapter options (Findings P1-5, P1-6, P2-12.2)', () => {
     expect(ctx.inputs.params).toEqual({ id: '9' });
     expect(ctx.thing).toEqual({ id: 't1' });
     expect(ctx.response).toEqual({ made: true });
+  });
+
+  it('routes afterResponse failures (sync and async) to onError with phase afterResponse', async () => {
+    const seen: { error: unknown; info: any }[] = [];
+    const syncThrower = toNextHandler(okStages, {
+      onError: (error, info) => seen.push({ error, info }),
+      afterResponse: () => {
+        throw new Error('audit write failed');
+      },
+    });
+    const res = await syncThrower(
+      postReq('http://localhost/api/x', {}),
+      routeCtx({})
+    );
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(seen).toHaveLength(1);
+    expect((seen[0].error as Error).message).toBe('audit write failed');
+    expect(seen[0].info.phase).toBe('afterResponse');
+
+    seen.length = 0;
+    const asyncRejector = toNextHandler(okStages, {
+      onError: (error, info) => seen.push({ error, info }),
+      afterResponse: async () => {
+        throw new Error('async audit write failed');
+      },
+    });
+    const res2 = await asyncRejector(
+      postReq('http://localhost/api/x', {}),
+      routeCtx({})
+    );
+    expect(res2.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(seen).toHaveLength(1);
+    expect((seen[0].error as Error).message).toBe('async audit write failed');
+    expect(seen[0].info.phase).toBe('afterResponse');
+  });
+
+  it('request-lifecycle onError calls carry no afterResponse phase', async () => {
+    const seen: any[] = [];
+    const handler = toNextHandler(
+      {
+        ...okStages,
+        execute: () => {
+          throw new Error('boom');
+        },
+      },
+      { onError: (_e, info) => seen.push(info) }
+    );
+    await handler(postReq('http://localhost/api/x', {}), routeCtx({}));
+    expect(seen).toHaveLength(1);
+    expect(seen[0].phase).toBeUndefined();
+  });
+
+  it('makeNextHandlerFactory bakes defaults; per-call options merge over them', async () => {
+    const gathered: string[] = [];
+    const toAppHandler = makeNextHandlerFactory({
+      gatherContext: async () => {
+        gathered.push('default');
+        return { principal: 'default-user' };
+      },
+    });
+
+    const withDefaults = toAppHandler({
+      extractAmbient: (raw: { principal: string }) => ({
+        principal: raw.principal,
+      }),
+      sanitizeInputs: (i: any) => i,
+      preAuthorize: () => true,
+      finalAuthorize: () => true,
+      execute: (ctx: { ambient: { principal: string } }) => ({
+        who: ctx.ambient.principal,
+      }),
+      redactResponse: (u: any) => u,
+    });
+    const res = await withDefaults(
+      postReq('http://localhost/api/me', {}),
+      routeCtx({})
+    );
+    expect(await res.json()).toEqual({ who: 'default-user' });
+    expect(gathered).toEqual(['default']);
+
+    const overridden = toAppHandler(
+      {
+        extractAmbient: (raw: { principal: string }) => ({
+          principal: raw.principal,
+        }),
+        sanitizeInputs: (i: any) => i,
+        preAuthorize: () => true,
+        finalAuthorize: () => true,
+        execute: (ctx: { ambient: { principal: string } }) => ({
+          who: ctx.ambient.principal,
+        }),
+        redactResponse: (u: any) => u,
+      },
+      { gatherContext: async () => ({ principal: 'override-user' }) }
+    );
+    const res2 = await overridden(
+      postReq('http://localhost/api/me', {}),
+      routeCtx({})
+    );
+    expect(await res2.json()).toEqual({ who: 'override-user' });
   });
 
   it('afterResponse does not fire on a failed request', async () => {

--- a/test/switch.test-d.ts
+++ b/test/switch.test-d.ts
@@ -1,0 +1,70 @@
+// Type-level tests for the switch composers: RedactResponseSwitch derives a
+// real deps-met context requirement from its dot-path key, and its response
+// type is the union of the case redactors' returns.
+import { describe, expectTypeOf, it } from 'vitest';
+import {
+  RedactResponse,
+  RedactResponseSwitch,
+  SanitizeInputsSwitch,
+  SanitizeInputs,
+} from '../src/index.js';
+import { toNextHandler } from '../src/next.js';
+
+const baseStages = {
+  sanitizeInputs: (i: any) => i,
+  preAuthorize: () => true,
+  execute: () => ({ names: ['a'] as string[], emails: ['e'] as string[] }),
+};
+
+const EmailAwareRedact = RedactResponseSwitch('canSeeEmails', {
+  true: RedactResponse((u: { names: string[]; emails: string[] }) => u),
+  false: RedactResponse((u: { names: string[]; emails: string[] }) => ({
+    names: u.names,
+  })),
+});
+
+describe('RedactResponseSwitch deps-met', () => {
+  it('compiles when a stage contributes the switch key', () => {
+    const handler = toNextHandler({
+      ...baseStages,
+      finalAuthorize: () => ({ canSeeEmails: true }),
+      ...EmailAwareRedact,
+    });
+    expectTypeOf(handler).toBeFunction();
+  });
+
+  it('fails deps-met when nothing contributes the switch key', () => {
+    const conf = {
+      ...baseStages,
+      finalAuthorize: () => true,
+      ...EmailAwareRedact,
+    };
+    // @ts-expect-error - nothing contributes `canSeeEmails` to the context
+    toNextHandler(conf);
+  });
+
+  it('types the response as the union of the case redactors', () => {
+    type Out = ReturnType<(typeof EmailAwareRedact)['redactResponse']>;
+    expectTypeOf<Out>().toEqualTypeOf<
+      { names: string[]; emails: string[] } | { names: string[] }
+    >();
+  });
+});
+
+describe('SanitizeInputsSwitch typing', () => {
+  it('types the sanitized inputs as the union of the case sanitizers', () => {
+    const frag = SanitizeInputsSwitch('body.kind', {
+      email: SanitizeInputs((u: any) => ({
+        body: { kind: 'email' as const, address: String(u.body.address) },
+      })),
+      sms: SanitizeInputs((u: any) => ({
+        body: { kind: 'sms' as const, number: String(u.body.number) },
+      })),
+    });
+    type Out = ReturnType<(typeof frag)['sanitizeInputs']>;
+    expectTypeOf<Out>().toEqualTypeOf<
+      | { body: { kind: 'email'; address: string } }
+      | { body: { kind: 'sms'; number: string } }
+    >();
+  });
+});

--- a/test/switch.test.ts
+++ b/test/switch.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RedactResponse,
+  RedactResponseSwitch,
+  SanitizeInputs,
+  SanitizeInputsSwitch,
+} from '../src/index.js';
+import { HipBadInputs, HipInternal } from '../src/errors.js';
+
+describe('RedactResponseSwitch (core)', () => {
+  const cases = {
+    admin: RedactResponse((u: { names: string[]; emails: string[] }) => u),
+    member: RedactResponse((u: { names: string[]; emails: string[] }) => ({
+      names: u.names,
+    })),
+  };
+  const unsafe = { names: ['a'], emails: ['a@x.co'] };
+
+  it('delegates to the case picked from a top-level context key', () => {
+    const { redactResponse } = RedactResponseSwitch('role', cases);
+    expect(redactResponse(unsafe, { role: 'member' })).toEqual({
+      names: ['a'],
+    });
+    expect(redactResponse(unsafe, { role: 'admin' })).toBe(unsafe);
+  });
+
+  it('supports a nested dot-path key (a key of a key)', () => {
+    const { redactResponse } = RedactResponseSwitch('principal.role', cases);
+    expect(
+      redactResponse(unsafe, { principal: { role: 'member' } } as any)
+    ).toEqual({ names: ['a'] });
+  });
+
+  it('stringifies boolean keys so true/false cases work', () => {
+    const { redactResponse } = RedactResponseSwitch('canSeeEmails', {
+      true: cases.admin,
+      false: cases.member,
+    });
+    expect(redactResponse(unsafe, { canSeeEmails: false })).toEqual({
+      names: ['a'],
+    });
+  });
+
+  it('passes the context through to the chosen (two-param) redactor', () => {
+    const { redactResponse } = RedactResponseSwitch('role', {
+      admin: {
+        redactResponse: (u: typeof unsafe, ctx: any) => ({
+          names: u.names,
+          decidedBy: ctx.role,
+        }),
+      },
+    });
+    expect(redactResponse(unsafe, { role: 'admin' })).toEqual({
+      names: ['a'],
+      decidedBy: 'admin',
+    });
+  });
+
+  it('throws HipInternal for an unregistered key without leaking it in the message', () => {
+    const { redactResponse } = RedactResponseSwitch('role', cases);
+    let caught: unknown;
+    try {
+      redactResponse(unsafe, { role: 'super-secret-role' });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(HipInternal);
+    expect((caught as HipInternal).message).not.toContain('super-secret-role');
+    expect((caught as HipInternal).detail).toEqual({
+      keyPath: 'role',
+      key: 'super-secret-role',
+    });
+  });
+});
+
+describe('SanitizeInputsSwitch (core)', () => {
+  const cases = {
+    email: SanitizeInputs((u: any) => ({
+      body: { kind: 'email' as const, address: String(u.body.address) },
+    })),
+    sms: SanitizeInputs((u: any) => ({
+      body: { kind: 'sms' as const, number: String(u.body.number) },
+    })),
+  };
+
+  it('delegates to the case picked from the unsafe inputs', () => {
+    const { sanitizeInputs } = SanitizeInputsSwitch('body.kind', cases);
+    expect(
+      sanitizeInputs({ body: { kind: 'sms', number: '555', junk: true } })
+    ).toEqual({ body: { kind: 'sms', number: '555' } });
+  });
+
+  it('rejects an unknown discriminator with HipBadInputs and a generic message', () => {
+    const { sanitizeInputs } = SanitizeInputsSwitch('body.kind', cases);
+    let caught: unknown;
+    try {
+      sanitizeInputs({ body: { kind: 'evil-$where' } });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(HipBadInputs);
+    expect((caught as HipBadInputs).message).not.toContain('evil');
+  });
+
+  it('rejects inputs where the discriminator path is absent', () => {
+    const { sanitizeInputs } = SanitizeInputsSwitch('body.kind', cases);
+    expect(() => sanitizeInputs({})).toThrow(HipBadInputs);
+  });
+});

--- a/test/zod.test.ts
+++ b/test/zod.test.ts
@@ -7,6 +7,7 @@ const {
   SanitizeInputsWithZod,
   SanitizeInputsSlicesWithZod,
   RedactResponseWithZod,
+  RedactResponseByRoleWithZod,
   PojoToValidated,
   stripIdTransform,
 } = htZodFactory();
@@ -142,5 +143,62 @@ describe('SanitizeInputsSlicesWithZod', () => {
     expect(sanitizeInputs({ body: { name: 'hip', _id: 'nope' } }).body).toEqual(
       { name: 'hip' }
     );
+  });
+});
+
+describe('RedactResponseByRoleWithZod', () => {
+  const memberSchema = z.object({ names: z.array(z.string()) });
+  const adminSchema = z.object({
+    names: z.array(z.string()),
+    emails: z.array(z.string()),
+  });
+  const unsafe = {
+    names: ['a', 'b'],
+    emails: ['a@x.co', 'b@x.co'],
+    internalFlag: true,
+  };
+
+  it('picks the schema by a boolean context flag', () => {
+    const { redactResponse } = RedactResponseByRoleWithZod(
+      (ctx: { canSeeEmails: boolean }) => ctx.canSeeEmails,
+      { true: adminSchema, false: memberSchema }
+    );
+    expect(redactResponse(unsafe, { canSeeEmails: true })).toEqual({
+      names: ['a', 'b'],
+      emails: ['a@x.co', 'b@x.co'],
+    });
+    expect(redactResponse(unsafe, { canSeeEmails: false })).toEqual({
+      names: ['a', 'b'],
+    });
+  });
+
+  it('picks the schema by a string role key', () => {
+    const { redactResponse } = RedactResponseByRoleWithZod(
+      (ctx: { role: 'admin' | 'member' }) => ctx.role,
+      { admin: adminSchema, member: memberSchema }
+    );
+    expect(redactResponse(unsafe, { role: 'member' })).toEqual({
+      names: ['a', 'b'],
+    });
+  });
+
+  it('throws HipInternal when no schema is registered for the key', () => {
+    const { redactResponse } = RedactResponseByRoleWithZod(
+      (ctx: { role: string }) => ctx.role,
+      { admin: adminSchema } as Record<string, typeof adminSchema>
+    );
+    expect(() => redactResponse(unsafe, { role: 'ghost' })).toThrow(
+      HipInternal
+    );
+  });
+
+  it('throws HipInternal when the chosen schema rejects the response', () => {
+    const { redactResponse } = RedactResponseByRoleWithZod(
+      (ctx: { canSeeEmails: boolean }) => ctx.canSeeEmails,
+      { true: adminSchema, false: memberSchema }
+    );
+    expect(() =>
+      redactResponse({ nope: true }, { canSeeEmails: true })
+    ).toThrow(HipInternal);
   });
 });

--- a/test/zod.test.ts
+++ b/test/zod.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { HipBadInputs, HipInternal } from '../src/errors';
+import { RedactResponseSwitch, SanitizeInputsSwitch } from '../src/index.js';
 import { htZodFactory } from '../src/zod';
 
 const {
   SanitizeInputsWithZod,
   SanitizeInputsSlicesWithZod,
   RedactResponseWithZod,
-  RedactResponseByRoleWithZod,
   PojoToValidated,
   stripIdTransform,
 } = htZodFactory();
@@ -146,7 +146,7 @@ describe('SanitizeInputsSlicesWithZod', () => {
   });
 });
 
-describe('RedactResponseByRoleWithZod', () => {
+describe('RedactResponseSwitch layered over RedactResponseWithZod', () => {
   const memberSchema = z.object({ names: z.array(z.string()) });
   const adminSchema = z.object({
     names: z.array(z.string()),
@@ -158,11 +158,11 @@ describe('RedactResponseByRoleWithZod', () => {
     internalFlag: true,
   };
 
-  it('picks the schema by a boolean context flag', () => {
-    const { redactResponse } = RedactResponseByRoleWithZod(
-      (ctx: { canSeeEmails: boolean }) => ctx.canSeeEmails,
-      { true: adminSchema, false: memberSchema }
-    );
+  it('picks the zod redactor by a boolean context flag', () => {
+    const { redactResponse } = RedactResponseSwitch('canSeeEmails', {
+      true: RedactResponseWithZod(adminSchema),
+      false: RedactResponseWithZod(memberSchema),
+    });
     expect(redactResponse(unsafe, { canSeeEmails: true })).toEqual({
       names: ['a', 'b'],
       emails: ['a@x.co', 'b@x.co'],
@@ -172,33 +172,43 @@ describe('RedactResponseByRoleWithZod', () => {
     });
   });
 
-  it('picks the schema by a string role key', () => {
-    const { redactResponse } = RedactResponseByRoleWithZod(
-      (ctx: { role: 'admin' | 'member' }) => ctx.role,
-      { admin: adminSchema, member: memberSchema }
-    );
-    expect(redactResponse(unsafe, { role: 'member' })).toEqual({
-      names: ['a', 'b'],
-    });
-  });
-
-  it('throws HipInternal when no schema is registered for the key', () => {
-    const { redactResponse } = RedactResponseByRoleWithZod(
-      (ctx: { role: string }) => ctx.role,
-      { admin: adminSchema } as Record<string, typeof adminSchema>
-    );
-    expect(() => redactResponse(unsafe, { role: 'ghost' })).toThrow(
-      HipInternal
-    );
-  });
-
   it('throws HipInternal when the chosen schema rejects the response', () => {
-    const { redactResponse } = RedactResponseByRoleWithZod(
-      (ctx: { canSeeEmails: boolean }) => ctx.canSeeEmails,
-      { true: adminSchema, false: memberSchema }
-    );
+    const { redactResponse } = RedactResponseSwitch('canSeeEmails', {
+      true: RedactResponseWithZod(adminSchema),
+      false: RedactResponseWithZod(memberSchema),
+    });
     expect(() =>
       redactResponse({ nope: true }, { canSeeEmails: true })
     ).toThrow(HipInternal);
+  });
+});
+
+describe('SanitizeInputsSwitch layered over SanitizeInputsSlicesWithZod', () => {
+  const emailCase = SanitizeInputsSlicesWithZod({
+    body: z.object({ kind: z.literal('email'), address: z.string() }),
+  });
+  const smsCase = SanitizeInputsSlicesWithZod({
+    body: z.object({ kind: z.literal('sms'), number: z.string() }),
+  });
+
+  it('routes to the matching zod slice sanitizer by a body discriminator', () => {
+    const { sanitizeInputs } = SanitizeInputsSwitch('body.kind', {
+      email: emailCase,
+      sms: smsCase,
+    });
+    const out: any = sanitizeInputs({
+      body: { kind: 'email', address: 'a@b.c', evil: 'x' },
+    });
+    expect(out.body).toEqual({ kind: 'email', address: 'a@b.c' });
+  });
+
+  it('rejects an unknown discriminator with HipBadInputs', () => {
+    const { sanitizeInputs } = SanitizeInputsSwitch('body.kind', {
+      email: emailCase,
+      sms: smsCase,
+    });
+    expect(() => sanitizeInputs({ body: { kind: 'carrier-pigeon' } })).toThrow(
+      HipBadInputs
+    );
   });
 });


### PR DESCRIPTION
## What does this PR do?

Addresses composability and DX gaps from real-world dogfooding on 0.12.0:

1. **`finishPipe(pipe, handler)`** — Composes a shared partial pipeline with ONE endpoint-specific trailing handler whose stage callbacks get their context parameter types **inferred from the pipe**. Zero hand-written annotations, phantom context keys are compile errors, and pipe-internal deps-met requirements (e.g. scoped finders' `queryScope`) still surface as `HipDepNotMet` at the adapter boundary. Runtime is literally `HTPipe(pipe, handler)`. The trailing handler is limited to `preAuthorize`/`loadResources`/`finalAuthorize`/`execute`/`redactResponse`/`responseMeta` (author extraction/sanitization in the pipe). Also exports `PipeContext<TPipe>` utility.

2. **Everyday mongoose loader fragments** — Module-level exports in `hipthrusts/mongoose`:
   - `LoadManyTo` — `Model.find(spec).lean()` → `ctx[key]: Lean<TRaw>[]`
   - `LoadOneTo` — `Model.findOne(spec).lean()` → `ctx[key]: Lean<TRaw> | null`
   - `LoadByIdRequiredTo` — `Model.findById(id).lean()`, throws `HipNotFound` when missing → `ctx[key]: Lean<TRaw>`
   - `LoadDocByIdRequiredTo` — `Model.findById(id)` hydrated (for `.set()`/`.save()` update flows), throws `HipNotFound` → `ctx[key]: HydratedDocument<TRaw>`
   
   Lean reads type as `TRaw & { _id: Types.ObjectId }`; doc types inferred from mongoose's own `Model<TRaw>` via type-only imports.

3. **`ctxRef('dot.path')` filter/id specs** — Declarative context-path references for loader filter/id specs. The fragment's context REQUIREMENT is derived from the path string via template-literal types, so deps-met enforces that an earlier stage provides the referenced value — with zero hand-written context annotations at the call site. ctxRef values get `$eq`-wrapped (NoSQL injection hygiene by default); literals pass through verbatim (escape hatch for operator filters).

4. **Adapter improvements**:
   - `onError` hook now receives `phase: 'afterResponse'` when the error escaped the `afterResponse` side-effect hook (response already sent)
   - Added preset factories (`makeNextHandlerFactory`, `makeExpressHandlerFactory`, etc.) to bake shared options into reusable handler converters
   - `afterResponse` failures now route to `onError` instead of silently failing

5. **Zod integration** — `RedactResponseByRoleWithZod` for role-dependent redaction (picks wire schema by a context-derived key).

## Checklist

- [x] Tests added/updated (type-level tests for `finishPipe` and loader fragments; runtime tests for loaders, `finishPipe`, and adapter options)
- [x] `pnpm test`, `pnpm lint`, `pnpm typecheck`, and `pnpm build` pass locally
- [x] Docs updated (README with partial pipelines, `finishPipe`, and preset factories; CHANGELOG with full feature list)

https://claude.ai/code/session_01UeTe4XwHytN564htsGqVkG