### PR TITLE
Pin mongoose toObject options and lock composed-authorizer merge with…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (before 1.0, minor releases could contain breaking changes).
 
+## [Unreleased]
+
+### Fixed
+
+- mongoose sanitizers and redactor: every shape-affecting `toObject` option
+  is now explicitly pinned to mongoose's defaults, so ambient config
+  (`mongoose.set('toObject', ...)` or schema-level options) can no longer
+  alter the shape of sanitized inputs or redacted responses ([#110](https://github.com/trycatchal/hipthrusts/issues/110)).
+
+### Tests
+
+- Runtime regression suite locking the composed-authorizer context merge
+  (left-returned context preserved through `HTPipe`'d `preAuthorize`/
+  `finalAuthorize`, short-circuiting, arity edges, and an end-to-end adapter
+  pass) ([#111](https://github.com/trycatchal/hipthrusts/issues/111), originally #37).
+
 ## [1.0.0] - 2026-07-17
 
 First stable release. No API changes since 0.13.0 — this release is the

--- a/src/mongoose.ts
+++ b/src/mongoose.ts
@@ -463,6 +463,19 @@ export function htMongooseFactory(mongoose: any) {
     return ret;
   }
 
+  // Every shape-affecting toObject option pinned to mongoose's defaults, so
+  // ambient config (mongoose.set('toObject', ...) or schema-level toObject
+  // options) can never alter the shape the sanitizers and redactor produce.
+  const pinnedToObjectOptions = {
+    getters: false,
+    virtuals: false,
+    aliases: false,
+    versionKey: true,
+    depopulate: false,
+    flattenMaps: false,
+    minimize: true,
+  };
+
   function deepWipeDefault(obj: any): any {
     if (Array.isArray(obj)) {
       return obj.map((elm) => deepWipeDefault(elm));
@@ -533,7 +546,10 @@ export function htMongooseFactory(mongoose: any) {
       if (validateErrors !== undefined) {
         throw new HipBadInputs('Inputs not valid');
       }
-      return doc.toObject({ transform: stripIdTransform }) as TSafe;
+      return doc.toObject({
+        ...pinnedToObjectOptions,
+        transform: stripIdTransform,
+      }) as TSafe;
     });
   }
 
@@ -558,7 +574,10 @@ export function htMongooseFactory(mongoose: any) {
           if (validateErrors !== undefined) {
             throw new HipBadInputs(`${sliceName} not valid`);
           }
-          return doc.toObject({ transform: stripIdTransform });
+          return doc.toObject({
+            ...pinnedToObjectOptions,
+            transform: stripIdTransform,
+          });
         },
       ])
     ) as {
@@ -615,7 +634,7 @@ export function htMongooseFactory(mongoose: any) {
   >(DocFactory: TDocFactory) {
     return RedactResponse((unsafeResponse: any) => {
       const doc = DocFactory(unsafeResponse);
-      return doc.toObject() as TSafeResponse;
+      return doc.toObject(pinnedToObjectOptions) as TSafeResponse;
     });
   }
 

--- a/test/authorizer-composition.test.ts
+++ b/test/authorizer-composition.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, vi } from 'vitest';
+import { HTPipe } from '../src';
+import { executeHipthrustable, withDefaultImplementations } from '../src/core';
+import { HipForbidden } from '../src/errors';
+import { toExpressHandler } from '../src/express';
+
+// Runtime regression tests for issue #111: composed authorizers must preserve
+// the left fragment's returned context (originally reported as #37). The
+// merge is type-level tested in composition.test-d.ts; these lock the runtime
+// behavior so a regression can't slip through type-checking.
+
+const emptyRawRequest = { params: {}, query: {}, body: {}, headers: {} };
+
+function runnable(fragments: Record<string, any>) {
+  return withDefaultImplementations({
+    sanitizeInputs: (i: any) => i,
+    preAuthorize: () => true,
+    finalAuthorize: () => true,
+    execute: () => ({ ok: true }),
+    redactResponse: (u: any) => u,
+    ...fragments,
+  } as any);
+}
+
+describe('composed preAuthorize preserves left-returned context', () => {
+  it('left object + right true: left keys reach downstream stages', async () => {
+    const piped = HTPipe(
+      { preAuthorize: () => ({ role: 'admin' }) },
+      { preAuthorize: () => true }
+    );
+    let executeCtx: any;
+    const handler = runnable({
+      ...piped,
+      execute: (ctx: any) => {
+        executeCtx = ctx;
+        return { ok: true };
+      },
+    });
+    await executeHipthrustable(handler, emptyRawRequest);
+    expect(executeCtx.role).toBe('admin');
+  });
+
+  it('left true + right object: right keys reach downstream stages', async () => {
+    const piped = HTPipe(
+      { preAuthorize: () => true },
+      { preAuthorize: () => ({ tier: 'gold' }) }
+    );
+    let executeCtx: any;
+    const handler = runnable({
+      ...piped,
+      execute: (ctx: any) => {
+        executeCtx = ctx;
+        return { ok: true };
+      },
+    });
+    await executeHipthrustable(handler, emptyRawRequest);
+    expect(executeCtx.tier).toBe('gold');
+  });
+
+  it('both objects: merged with right-wins on collisions', () => {
+    const piped = HTPipe(
+      { preAuthorize: () => ({ role: 'admin', tier: 1 }) },
+      { preAuthorize: () => ({ tier: 2 }) }
+    );
+    expect((piped as any).preAuthorize({})).toEqual({ role: 'admin', tier: 2 });
+  });
+
+  it('the right authorizer receives the left-returned keys in its input', () => {
+    let rightSaw: any;
+    const piped = HTPipe(
+      { preAuthorize: () => ({ role: 'admin' }) },
+      {
+        preAuthorize: (ctx: any) => {
+          rightSaw = ctx.role;
+          return true;
+        },
+      }
+    );
+    (piped as any).preAuthorize({});
+    expect(rightSaw).toBe('admin');
+  });
+
+  it('left false short-circuits: right never runs and the request is forbidden', async () => {
+    const rightSpy = vi.fn(() => true);
+    const piped = HTPipe(
+      { preAuthorize: () => false as const },
+      { preAuthorize: rightSpy }
+    );
+    const handler = runnable({ ...piped });
+    await expect(
+      executeHipthrustable(handler, emptyRawRequest)
+    ).rejects.toBeInstanceOf(HipForbidden);
+    expect(rightSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('composed finalAuthorize preserves left-returned context', () => {
+  it('left object + right true: left keys reach execute', async () => {
+    const piped = HTPipe(
+      { finalAuthorize: () => ({ ownerChecked: true }) },
+      { finalAuthorize: () => true }
+    );
+    let executeCtx: any;
+    const handler = runnable({
+      ...piped,
+      execute: (ctx: any) => {
+        executeCtx = ctx;
+        return { ok: true };
+      },
+    });
+    await executeHipthrustable(handler, emptyRawRequest);
+    expect(executeCtx.ownerChecked).toBe(true);
+  });
+
+  it('left true + right object: right keys reach execute', async () => {
+    const piped = HTPipe(
+      { finalAuthorize: () => true },
+      { finalAuthorize: () => ({ audit: 'pass' }) }
+    );
+    let executeCtx: any;
+    const handler = runnable({
+      ...piped,
+      execute: (ctx: any) => {
+        executeCtx = ctx;
+        return { ok: true };
+      },
+    });
+    await executeHipthrustable(handler, emptyRawRequest);
+    expect(executeCtx.audit).toBe('pass');
+  });
+
+  it('both objects: merged with right-wins on collisions', async () => {
+    const piped = HTPipe(
+      { finalAuthorize: () => ({ scope: 'own', level: 1 }) },
+      { finalAuthorize: () => ({ level: 2 }) }
+    );
+    await expect((piped as any).finalAuthorize({})).resolves.toEqual({
+      scope: 'own',
+      level: 2,
+    });
+  });
+
+  it('the right authorizer receives the left-returned keys (async left)', async () => {
+    let rightSaw: any;
+    const piped = HTPipe(
+      { finalAuthorize: async () => ({ doc: { ownerId: 'u1' } }) },
+      {
+        finalAuthorize: (ctx: any) => {
+          rightSaw = ctx.doc;
+          return true;
+        },
+      }
+    );
+    await (piped as any).finalAuthorize({});
+    expect(rightSaw).toEqual({ ownerId: 'u1' });
+  });
+
+  it('left false short-circuits: right never runs and the request is forbidden', async () => {
+    const rightSpy = vi.fn(() => true);
+    const piped = HTPipe(
+      { finalAuthorize: () => false as const },
+      { finalAuthorize: rightSpy }
+    );
+    const handler = runnable({ ...piped });
+    await expect(
+      executeHipthrustable(handler, emptyRawRequest)
+    ).rejects.toBeInstanceOf(HipForbidden);
+    expect(rightSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('composition arity edges (runtime)', () => {
+  it('a single-fragment pipe passes authorizer context through unchanged', async () => {
+    const piped = HTPipe({ preAuthorize: () => ({ solo: true }) });
+    let executeCtx: any;
+    const handler = runnable({
+      ...piped,
+      execute: (ctx: any) => {
+        executeCtx = ctx;
+        return { ok: true };
+      },
+    });
+    await executeHipthrustable(handler, emptyRawRequest);
+    expect(executeCtx.solo).toBe(true);
+  });
+
+  it('a four-fragment authorizer pipe accumulates context left to right', () => {
+    const piped = HTPipe(
+      { preAuthorize: () => ({ a: 1 }) },
+      { preAuthorize: () => true },
+      { preAuthorize: (ctx: any) => ({ b: ctx.a + 1 }) },
+      { preAuthorize: () => ({ c: 3 }) }
+    );
+    expect((piped as any).preAuthorize({})).toEqual({ a: 1, b: 2, c: 3 });
+  });
+});
+
+describe('end-to-end: piped pre+final authorizer chain through the express adapter', () => {
+  function fakeRes(): any {
+    return {
+      statusCode: 200,
+      body: undefined as any,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(b: any) {
+        this.body = b;
+      },
+      setHeader() {},
+    };
+  }
+
+  it('execute sees every authorizer-contributed key', async () => {
+    const pre = HTPipe(
+      { preAuthorize: () => ({ fromPreLeft: 1 }) },
+      { preAuthorize: (ctx: any) => ({ fromPreRight: ctx.fromPreLeft + 1 }) }
+    );
+    const fin = HTPipe(
+      {
+        finalAuthorize: (ctx: any) => ({ fromFinalLeft: ctx.fromPreRight + 1 }),
+      },
+      {
+        finalAuthorize: (ctx: any) => ({
+          fromFinalRight: ctx.fromFinalLeft + 1,
+        }),
+      }
+    );
+    const handler = toExpressHandler({
+      sanitizeInputs: (i: any) => i,
+      ...pre,
+      ...fin,
+      execute: (ctx: any) => ({
+        sum:
+          ctx.fromPreLeft +
+          ctx.fromPreRight +
+          ctx.fromFinalLeft +
+          ctx.fromFinalRight,
+      }),
+      redactResponse: (u: any) => u,
+    } as any);
+    const res = fakeRes();
+    await handler(
+      { params: {}, query: {}, body: {}, headers: {} } as any,
+      res,
+      vi.fn()
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ sum: 10 });
+  });
+});

--- a/test/mongoose.test.ts
+++ b/test/mongoose.test.ts
@@ -115,6 +115,60 @@ describe('SanitizeInputsSlicesWithMongoose', () => {
   });
 });
 
+describe('toObject shape pinning under ambient mongoose config (#110)', () => {
+  // Global toObject config is baked into schemas at construction time, so the
+  // override must be in place BEFORE the factory creates its schema — the
+  // realistic ordering for app-level config set at boot.
+  function withGlobalToObject<T>(options: object, fn: () => T): T {
+    const prior = mongoose.get('toObject');
+    mongoose.set('toObject', options as any);
+    try {
+      return fn();
+    } finally {
+      mongoose.set('toObject', prior as any);
+    }
+  }
+
+  it('SanitizeInputsWithMongoose ignores a global getters/virtuals override', () => {
+    withGlobalToObject({ getters: true, virtuals: true }, () => {
+      const factory = ht.documentFactoryFromForRequest({
+        name: {
+          type: String,
+          required: true,
+          get: (v: string) => `GETTER:${v}`,
+        },
+      });
+      const { sanitizeInputs } = ht.SanitizeInputsWithMongoose(factory);
+      expect(sanitizeInputs({ name: 'hip' })).toEqual({ name: 'hip' });
+    });
+  });
+
+  it('SanitizeInputsSlicesWithMongoose ignores a global getters/virtuals override', () => {
+    withGlobalToObject({ getters: true, virtuals: true }, () => {
+      const sliceFactory = ht.documentFactoryFromForRequest({
+        id: { type: String, required: true, get: (v: string) => `GETTER:${v}` },
+      });
+      const { sanitizeInputs } = ht.SanitizeInputsSlicesWithMongoose({
+        params: sliceFactory,
+      });
+      expect(sanitizeInputs({ params: { id: '7' } }).params).toEqual({
+        id: '7',
+      });
+    });
+  });
+
+  it('RedactResponseWithMongoose ignores a global getters/virtuals override', () => {
+    withGlobalToObject({ getters: true, virtuals: true }, () => {
+      const factory = ht.documentFactoryFromForResponse({
+        name: { type: String, get: (v: string) => `GETTER:${v}` },
+      });
+      const { redactResponse } = ht.RedactResponseWithMongoose(factory);
+      const result = redactResponse({ name: 'x' }) as any;
+      expect(result.name).toBe('x');
+    });
+  });
+});
+
 describe('SaveOnDocumentFrom', () => {
   it('saves the document found on the context key', async () => {
     const { execute } = ht.SaveOnDocumentFrom('doc');


### PR DESCRIPTION
… runtime tests

Closes #110: SanitizeInputsWithMongoose, SanitizeInputsSlicesWithMongoose, and RedactResponseWithMongoose now pass every shape-affecting toObject option explicitly (getters, virtuals, aliases, versionKey, depopulate, flattenMaps, minimize), so a global mongoose.set('toObject', ...) or schema-level override can never alter the sanitized/redacted shape. Regression tests verified red against the unpinned implementation.

Closes #111: runtime regression suite for composed authorizers — left- returned context preserved (object+true, true+object, both-objects with right-wins), right authorizer receives left's keys, left-false short- circuits without running the right, single- and four-fragment arity edges, and an end-to-end express-adapter pass asserting execute sees every authorizer-contributed key. Originally reported as #37; the fix already existed, these lock it against regression since only type-level coverage existed before.

Full suite: 228 tests passing (16 new), typecheck/lint/format clean.


Claude-Session: https://claude.ai/code/session_017AHqt5MqexQaTq2hjZXYdF

## What does this PR do?

<!-- Motivation and a short summary of the change. -->

## Checklist

- [ ] Tests added/updated (type-level tests for changes to the type machinery)
- [ ] `pnpm test`, `pnpm lint`, `pnpm typecheck`, and `pnpm build` pass locally
- [ ] Docs updated (README / examples) if the public API changed
