### PR TITLE
Add comprehensive architecture documentation with diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ subpath type declarations.
 
 ## The lifecycle, in detail
 
+Prefer pictures? [docs/architecture.md](./docs/architecture.md) has
+diagrams of the lifecycle, failure routing, `HTPipe` composition, the
+adapter surface, and the input-slice strictness guarantee.
+
 Every handler config is a plain object. Five methods are required; three
 are optional. Each method receives a `context` that accumulates as the
 request progresses, so a later stage sees everything earlier stages

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ subpath type declarations.
 ## The lifecycle, in detail
 
 Prefer pictures? [docs/architecture.md](./docs/architecture.md) has
-diagrams of the lifecycle, failure routing, `HTPipe` composition, the
-adapter surface, and the input-slice strictness guarantee.
+diagrams of the lifecycle, failure routing, context accumulation,
+`HTPipe` composition, and the adapter surface.
 
 Every handler config is a plain object. Five methods are required; three
 are optional. Each method receives a `context` that accumulates as the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,270 @@
+# HipThrusTS, visually
+
+Five diagrams that explain how HipThrusTS works and why it exists:
+
+1. [The lifecycle](#1-the-lifecycle) — the eight stages, how context
+   accumulates, and how flow control moves through them
+2. [Failure routing](#2-failure-routing) — how each stage's failures map to
+   client-safe responses
+3. [Composition with `HTPipe`](#3-composition-with-htpipe) — how fragments
+   merge, and how a single request snakes across the whole pipe one
+   lifecycle stage at a time
+4. [Adapters](#4-adapters) — framework adapters on the outside, schema and
+   data-model adapters plugged into individual stages
+5. [The strictness guarantee](#5-the-strictness-guarantee) — why an
+   unsanitized input slice can never reach your business logic
+
+All diagrams are Mermaid, so GitHub renders them natively and they get
+reviewed in the same diff as the code they describe.
+
+## 1. The lifecycle
+
+Every handler is the same eight stages (five required, three optional),
+run in a fixed order by `executeHipthrustable`. The context is a plain
+object that **accumulates**: each stage receives everything earlier stages
+produced, and later stages can consume it with full type inference.
+
+Authorization stages return `true` to pass, `false` to deny, or an
+**object** to pass *and* contribute that object's keys to the context.
+
+```mermaid
+flowchart TD
+    RAW(["Raw request<br/>(framework-specific)"])
+
+    EA["<b>extractAmbient</b> · optional, sync<br/>lift trusted ambient: auth principal, request ID"]
+    EI["<b>extractInputs</b> · optional, sync<br/>adapter-specific input shaping"]
+    SI["<b>sanitizeInputs</b> · required, sync<br/>untrusted in → validated, typed out"]
+    PA{"<b>preAuthorize</b> · required, sync<br/>cheap check before touching the DB"}
+    LR["<b>loadResources</b> · optional, async<br/>fetch the resource the request is about"]
+    FA{"<b>finalAuthorize</b> · required, async<br/>ownership check with the resource in hand"}
+    EX["<b>execute</b> · required, async<br/>the actual work"]
+    RR["<b>redactResponse</b> · required, sync<br/>strip fields the caller may not see"]
+
+    RESP(["Safe response"])
+    DENY(["HipForbidden → 403"])
+
+    RAW --> EA
+    EA -->|"ctx.ambient = { user, … }"| EI
+    EI -->|"unsafe inputs"| SI
+    SI -->|"ctx.inputs = validated shape"| PA
+    PA -->|"true / object → spread into ctx"| LR
+    PA -->|"false"| DENY
+    LR -->|"ctx.thing = loaded doc"| FA
+    FA -->|"true / object → spread into ctx<br/>e.g. { isOwner: true }"| EX
+    FA -->|"false"| DENY
+    EX -->|"unsafe response"| RR
+    RR --> RESP
+```
+
+The five required stages are **mandatory by construction**: an adapter
+won't accept a config that's missing one — it's a compile error, not a
+code-review catch.
+
+## 2. Failure routing
+
+Flow control on the unhappy path is just as fixed as the happy path.
+Throw a `HipError` from any stage and the adapter translates it to the
+right transport response (HTTP status, or `TRPCError` code). Anything
+*unexpected* thrown from a stage is routed by **which stage it escaped
+from** — so a dropped DB connection can never masquerade as "not found,"
+and no stack trace ever leaks to the caller.
+
+```mermaid
+flowchart LR
+    subgraph STAGES["Stage that threw"]
+        direction TB
+        S1["extractAmbient / extractInputs / sanitizeInputs"]
+        S2["preAuthorize / finalAuthorize<br/>returned false"]
+        S3["any stage:<br/>threw a HipError deliberately"]
+        S4["preAuthorize / loadResources /<br/>finalAuthorize / execute / redactResponse:<br/>unknown throw (bug, outage)"]
+    end
+
+    subgraph OUT["What the client sees"]
+        direction TB
+        E422["HipBadInputs → 422<br/>(these stages exist to reject bad input;<br/>original error chained as cause)"]
+        E403["HipForbidden → 403"]
+        EMAP["That error's own status:<br/>HipNotFound → 404, HipConflict → 409,<br/>HipUnauthorized → 401, …"]
+        E500["HipInternal → 500<br/>one scrubbed message,<br/>cause chained for logging"]
+    end
+
+    S1 --> E422
+    S2 --> E403
+    S3 --> EMAP
+    S4 --> E500
+```
+
+## 3. Composition with `HTPipe`
+
+The real payoff is writing a fragment once — "load the Thing, require the
+caller to own it" — and reusing it everywhere. `HTPipe` merges fragments
+**stage by stage**, not end to end:
+
+```mermaid
+flowchart LR
+    F1["WithUserFromReq<br/><i>extractAmbient</i>"]
+    F2["SanitizeInputsSlices<br/><i>sanitizeInputs</i>"]
+    F3["RequireThingOwner<br/><i>loadResources<br/>finalAuthorize</i>"]
+    F4["endpoint handler<br/><i>preAuthorize<br/>execute<br/>redactResponse</i>"]
+
+    PIPE(["HTPipe(…)"])
+    OUT["<b>one complete handler</b><br/>every stage present,<br/>each stage = its fragments chained left→right,<br/>context types intersected"]
+
+    F1 --> PIPE
+    F2 --> PIPE
+    F3 --> PIPE
+    F4 --> PIPE
+    PIPE --> OUT
+```
+
+At **runtime**, this means a single request does *not* run fragment 1
+start-to-finish, then fragment 2. Instead, each lifecycle stage sweeps
+left-to-right across every fragment that declares it — threading the
+accumulating context through — and only then does the request move to the
+next stage, back at the start of the pipe:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as core lifecycle
+    participant U as WithUserFromReq
+    participant S as SanitizeSlices
+    participant O as RequireThingOwner
+    participant H as endpoint handler
+
+    Note over C,H: extractAmbient
+    C->>U: extractAmbient(raw)
+    U-->>C: { user } → ctx.ambient
+
+    Note over C,H: sanitizeInputs
+    C->>S: sanitizeInputs(unsafe)
+    S-->>C: { params, body } → ctx.inputs
+
+    Note over C,H: preAuthorize
+    C->>H: preAuthorize(ctx)
+    H-->>C: true
+
+    Note over C,H: loadResources — back to the pipe's middle
+    C->>O: loadResources(ctx)
+    O-->>C: { thing } → ctx.thing
+
+    Note over C,H: finalAuthorize
+    C->>O: finalAuthorize(ctx)
+    O-->>C: { isOwner: true } → ctx.isOwner
+
+    Note over C,H: execute
+    C->>H: execute(ctx)
+    H-->>C: unsafe result
+
+    Note over C,H: redactResponse
+    C->>H: redactResponse(unsafe, ctx)
+    H-->>C: safe response
+```
+
+When **two fragments declare the same stage**, they chain within that
+stage, left to right, and flow control short-circuits:
+
+```mermaid
+flowchart LR
+    IN["ctx in"] --> L{"left fragment's<br/>finalAuthorize"}
+    L -->|"object / true<br/>(contribution spread into ctx)"| R{"right fragment's<br/>finalAuthorize"}
+    L -->|"false"| DENY(["stage denies —<br/>right never runs"])
+    R -->|"object / true"| PASS(["stage passes;<br/>both contributions merged"])
+    R -->|"false"| DENY
+```
+
+(`sanitizeInputs` chains output→input like a classic pipe;
+`redactResponse` chains the same way, so redactors stack; `execute` runs
+both and keeps the right result; loaders and authorizers merge their
+contributions as shown.)
+
+`finishPipe(pipe, handler)` is the ergonomic finish for the dominant
+shape — one shared pipe plus one endpoint-specific trailing handler —
+with the trailing handler's context types **inferred** from the pipe, so
+its callbacks need zero annotations.
+
+## 4. Adapters
+
+The lifecycle is framework-agnostic. Three kinds of adapters plug into
+it, and none of them know about each other:
+
+- **Endpoint handler adapters** wrap the whole lifecycle for a framework
+  (~100 lines each — anything else is a small PR away).
+- **Schema validation adapters** produce `sanitizeInputs` fragments from
+  a schema library.
+- **Data-model adapters** produce `loadResources` fragments (and
+  redaction helpers) from your ORM/ODM.
+
+```mermaid
+flowchart LR
+    subgraph FW["Endpoint handler adapters"]
+        direction TB
+        EXP["Express<br/><code>toExpressHandler</code>"]
+        TRPC["tRPC<br/><code>toTrpcProcedure</code>"]
+        HONO["Hono<br/><code>toHonoHandler</code>"]
+        FAST["Fastify<br/><code>toFastifyHandler</code>"]
+        NEXT["Next.js App Router<br/><code>toNextHandler</code>"]
+    end
+
+    subgraph CORE["Core lifecycle (framework-free)"]
+        direction TB
+        LC["extractAmbient → extractInputs →<br/>sanitizeInputs → preAuthorize →<br/>loadResources → finalAuthorize →<br/>execute → redactResponse"]
+    end
+
+    subgraph PLUG["Stage-fragment adapters"]
+        direction TB
+        ZOD["<b>Zod</b> (schema validation)<br/>SanitizeInputsWithZod<br/>SanitizeInputsSlicesWithZod<br/>→ sanitizeInputs fragments"]
+        MOO["<b>Mongoose</b> (data model)<br/>LoadByIdRequiredTo, FindScoped, …<br/>→ loadResources fragments<br/>json-mask → redaction helpers"]
+        USR["<b>Auth helpers</b><br/>roleCheckersOnRoleKey,<br/>assigneeCheckersOnIdKey<br/>→ authorize fragments"]
+    end
+
+    EXP -->|"canonical raw inputs<br/>{ params, query, body, headers }"| CORE
+    TRPC -->|"single input + ctx"| CORE
+    HONO --> CORE
+    FAST --> CORE
+    NEXT --> CORE
+
+    CORE -->|"safe response /<br/>HipError → status or TRPCError"| FW
+
+    ZOD -.->|"plug into<br/>sanitizeInputs"| CORE
+    MOO -.->|"plug into<br/>loadResources"| CORE
+    USR -.->|"plug into<br/>pre/finalAuthorize"| CORE
+```
+
+The framework adapter owns exactly two jobs: hand the lifecycle a
+canonical raw request, and translate the outcome (safe response, or a
+`HipError`) into its transport's vocabulary. Everything security-relevant
+lives in the framework-free middle — which is why the same shared
+fragments work unchanged across Express and tRPC.
+
+## 5. The strictness guarantee
+
+Slice-style sanitizers (`SanitizeInputsSlices`) hand the raw remainder to
+each other under a hidden `UNSAFE_SLICES` channel, and core **deletes that
+channel** when the sanitize stage completes. Only slices you explicitly
+sanitized survive — at runtime *and* in the types (consuming a dropped
+slice downstream is a compile error).
+
+```mermaid
+flowchart LR
+    RAW["raw inputs<br/>{ params, query, body, headers }"]
+
+    subgraph STAGE["sanitizeInputs stage"]
+        direction LR
+        SP["slice sanitizer<br/>params ✓"]
+        SB["slice sanitizer<br/>body ✓"]
+    end
+
+    BOUNDARY{{"stage boundary:<br/>UNSAFE_SLICES deleted"}}
+
+    SAFE["ctx.inputs = { params, body }<br/>typed, validated"]
+    GONE(["query, headers: gone —<br/>never reach preAuthorize or beyond;<br/>referencing them is a compile error"])
+
+    RAW --> SP
+    SP -->|"sanitized: { params }<br/>+ raw remainder via UNSAFE_SLICES"| SB
+    SB -->|"sanitized: { params, body }<br/>+ raw remainder"| BOUNDARY
+    BOUNDARY --> SAFE
+    BOUNDARY -.-> GONE
+```
+
+Want a raw slice through anyway? Say so explicitly — `{ query: (q) => q }`
+is a visible, greppable decision instead of a silent default.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,28 +1,30 @@
 # HipThrusTS, visually
 
-Five diagrams that explain how HipThrusTS works and why it exists:
+Six views that explain how HipThrusTS works and why it exists:
 
-1. [The lifecycle](#1-the-lifecycle) — the eight stages, how context
-   accumulates, and how flow control moves through them
+1. [The lifecycle](#1-the-lifecycle) — the eight stages and how flow
+   control moves through them
 2. [Failure routing](#2-failure-routing) — how each stage's failures map to
    client-safe responses
-3. [Composition with `HTPipe`](#3-composition-with-htpipe) — how fragments
-   merge, and how a single request snakes across the whole pipe one
-   lifecycle stage at a time
-4. [Adapters](#4-adapters) — framework adapters on the outside, schema and
-   data-model adapters plugged into individual stages
-5. [The strictness guarantee](#5-the-strictness-guarantee) — why an
-   unsanitized input slice can never reach your business logic
+3. [From raw request to initial context](#3-from-raw-request-to-initial-context)
+   — the trusted and untrusted halves of a request, and why unsanitized
+   slices can't survive
+4. [The context only grows](#4-the-context-only-grows) — how every stage
+   layers its contribution onto what came before
+5. [Composition with `HTPipe`](#5-composition-with-htpipe) — one request
+   sweeping the whole pipe stage by stage
+6. [Adapters](#6-adapters) — thin edges around a framework-free middle
 
-All diagrams are Mermaid, so GitHub renders them natively and they get
-reviewed in the same diff as the code they describe.
+Simple flows are Mermaid (GitHub renders it natively, and it's reviewed in
+the same diff as the code it describes). The spatial ones — the growing
+context stack, the pipe sweep, the adapter surface — are hand-drawn SVGs
+in [`img/`](./img), also plain text in the diff, drawn with theme-neutral
+colors so they read correctly in both GitHub light and dark mode.
 
 ## 1. The lifecycle
 
 Every handler is the same eight stages (five required, three optional),
-run in a fixed order by `executeHipthrustable`. The context is a plain
-object that **accumulates**: each stage receives everything earlier stages
-produced, and later stages can consume it with full type inference.
+run in a fixed order by `executeHipthrustable`.
 
 Authorization stages return `true` to pass, `false` to deny, or an
 **object** to pass *and* contribute that object's keys to the context.
@@ -93,178 +95,86 @@ flowchart LR
     S4 --> E500
 ```
 
-## 3. Composition with `HTPipe`
+## 3. From raw request to initial context
 
-The real payoff is writing a fragment once — "load the Thing, require the
-caller to own it" — and reusing it everywhere. `HTPipe` merges fragments
-**stage by stage**, not end to end:
-
-```mermaid
-flowchart LR
-    F1["WithUserFromReq<br/><i>extractAmbient</i>"]
-    F2["SanitizeInputsSlices<br/><i>sanitizeInputs</i>"]
-    F3["RequireThingOwner<br/><i>loadResources<br/>finalAuthorize</i>"]
-    F4["endpoint handler<br/><i>preAuthorize<br/>execute<br/>redactResponse</i>"]
-
-    PIPE(["HTPipe(…)"])
-    OUT["<b>one complete handler</b><br/>every stage present,<br/>each stage = its fragments chained left→right,<br/>context types intersected"]
-
-    F1 --> PIPE
-    F2 --> PIPE
-    F3 --> PIPE
-    F4 --> PIPE
-    PIPE --> OUT
-```
-
-At **runtime**, this means a single request does *not* run fragment 1
-start-to-finish, then fragment 2. Instead, each lifecycle stage sweeps
-left-to-right across every fragment that declares it — threading the
-accumulating context through — and only then does the request move to the
-next stage, back at the start of the pipe:
+A request object carries two very different kinds of data, and the first
+two lifecycle stages exist to keep them apart. Things the **caller
+controls** (params, body, query, headers) are untrusted and must pass
+through `sanitizeInputs`. Things **your own middleware produced** before
+the handler ran (`req.user` from your auth layer, a request ID, a locale)
+are trusted, and `extractAmbient` lifts them directly.
 
 ```mermaid
-sequenceDiagram
-    autonumber
-    participant C as core lifecycle
-    participant U as WithUserFromReq
-    participant S as SanitizeSlices
-    participant O as RequireThingOwner
-    participant H as endpoint handler
+flowchart TD
+    REQ["request object"]
 
-    Note over C,H: extractAmbient
-    C->>U: extractAmbient(raw)
-    U-->>C: { user } → ctx.ambient
-
-    Note over C,H: sanitizeInputs
-    C->>S: sanitizeInputs(unsafe)
-    S-->>C: { params, body } → ctx.inputs
-
-    Note over C,H: preAuthorize
-    C->>H: preAuthorize(ctx)
-    H-->>C: true
-
-    Note over C,H: loadResources — back to the pipe's middle
-    C->>O: loadResources(ctx)
-    O-->>C: { thing } → ctx.thing
-
-    Note over C,H: finalAuthorize
-    C->>O: finalAuthorize(ctx)
-    O-->>C: { isOwner: true } → ctx.isOwner
-
-    Note over C,H: execute
-    C->>H: execute(ctx)
-    H-->>C: unsafe result
-
-    Note over C,H: redactResponse
-    C->>H: redactResponse(unsafe, ctx)
-    H-->>C: safe response
-```
-
-When **two fragments declare the same stage**, they chain within that
-stage, left to right, and flow control short-circuits:
-
-```mermaid
-flowchart LR
-    IN["ctx in"] --> L{"left fragment's<br/>finalAuthorize"}
-    L -->|"object / true<br/>(contribution spread into ctx)"| R{"right fragment's<br/>finalAuthorize"}
-    L -->|"false"| DENY(["stage denies —<br/>right never runs"])
-    R -->|"object / true"| PASS(["stage passes;<br/>both contributions merged"])
-    R -->|"false"| DENY
-```
-
-(`sanitizeInputs` chains output→input like a classic pipe;
-`redactResponse` chains the same way, so redactors stack; `execute` runs
-both and keeps the right result; loaders and authorizers merge their
-contributions as shown.)
-
-`finishPipe(pipe, handler)` is the ergonomic finish for the dominant
-shape — one shared pipe plus one endpoint-specific trailing handler —
-with the trailing handler's context types **inferred** from the pipe, so
-its callbacks need zero annotations.
-
-## 4. Adapters
-
-The lifecycle is framework-agnostic. Three kinds of adapters plug into
-it, and none of them know about each other:
-
-- **Endpoint handler adapters** wrap the whole lifecycle for a framework
-  (~100 lines each — anything else is a small PR away).
-- **Schema validation adapters** produce `sanitizeInputs` fragments from
-  a schema library.
-- **Data-model adapters** produce `loadResources` fragments (and
-  redaction helpers) from your ORM/ODM.
-
-```mermaid
-flowchart LR
-    subgraph FW["Endpoint handler adapters"]
-        direction TB
-        EXP["Express<br/><code>toExpressHandler</code>"]
-        TRPC["tRPC<br/><code>toTrpcProcedure</code>"]
-        HONO["Hono<br/><code>toHonoHandler</code>"]
-        FAST["Fastify<br/><code>toFastifyHandler</code>"]
-        NEXT["Next.js App Router<br/><code>toNextHandler</code>"]
+    subgraph UT["untrusted — the caller controls this"]
+        P["params"]
+        B["body"]
+        Q["query · headers · …"]
     end
+    MW["trusted — produced by your own<br/>prior middleware: req.user, request ID"]
 
-    subgraph CORE["Core lifecycle (framework-free)"]
-        direction TB
-        LC["extractAmbient → extractInputs →<br/>sanitizeInputs → preAuthorize →<br/>loadResources → finalAuthorize →<br/>execute → redactResponse"]
-    end
+    SI["<b>sanitizeInputs</b><br/>validate every slice you want to keep"]
+    EA["<b>extractAmbient</b><br/>lift what you already trust"]
 
-    subgraph PLUG["Stage-fragment adapters"]
-        direction TB
-        ZOD["<b>Zod</b> (schema validation)<br/>SanitizeInputsWithZod<br/>SanitizeInputsSlicesWithZod<br/>→ sanitizeInputs fragments"]
-        MOO["<b>Mongoose</b> (data model)<br/>LoadByIdRequiredTo, FindScoped, …<br/>→ loadResources fragments<br/>json-mask → redaction helpers"]
-        USR["<b>Auth helpers</b><br/>roleCheckersOnRoleKey,<br/>assigneeCheckersOnIdKey<br/>→ authorize fragments"]
-    end
+    DROP(["slices you didn't sanitize are deleted<br/>at the stage boundary — consuming one<br/>downstream is a compile error"])
+    CTX["<b>initial context</b><br/>ctx.ambient — trusted<br/>ctx.inputs — validated"]
 
-    EXP -->|"canonical raw inputs<br/>{ params, query, body, headers }"| CORE
-    TRPC -->|"single input + ctx"| CORE
-    HONO --> CORE
-    FAST --> CORE
-    NEXT --> CORE
-
-    CORE -->|"safe response /<br/>HipError → status or TRPCError"| FW
-
-    ZOD -.->|"plug into<br/>sanitizeInputs"| CORE
-    MOO -.->|"plug into<br/>loadResources"| CORE
-    USR -.->|"plug into<br/>pre/finalAuthorize"| CORE
+    REQ --> UT
+    REQ --> MW
+    P -->|"validated"| SI
+    B -->|"validated"| SI
+    Q -.->|"not sanitized"| DROP
+    MW --> EA
+    SI -->|"ctx.inputs"| CTX
+    EA -->|"ctx.ambient"| CTX
 ```
 
-The framework adapter owns exactly two jobs: hand the lifecycle a
-canonical raw request, and translate the outcome (safe response, or a
-`HipError`) into its transport's vocabulary. Everything security-relevant
-lives in the framework-free middle — which is why the same shared
-fragments work unchanged across Express and tRPC.
+That drop is the **strictness guarantee**: slice sanitizers pass the raw
+remainder to each other on a hidden `UNSAFE_SLICES` channel, and core
+deletes that channel the moment the stage completes — at runtime *and* in
+the types. Want a raw slice through anyway? Say so explicitly
+(`{ query: (q) => q }`) — a visible, greppable decision instead of a
+silent default.
 
-## 5. The strictness guarantee
+## 4. The context only grows
 
-Slice-style sanitizers (`SanitizeInputsSlices`) hand the raw remainder to
-each other under a hidden `UNSAFE_SLICES` channel, and core **deletes that
-channel** when the sanitize stage completes. Only slices you explicitly
-sanitized survive — at runtime *and* in the types (consuming a dropped
-slice downstream is a compile error).
+From the initial context onward, every stage receives everything earlier
+stages produced and layers on its own contribution. `execute` written at
+the end of a long chain can reach `ctx.ambient.user`,
+`ctx.inputs.params.id`, `ctx.thing`, and `ctx.isOwner` — with full type
+inference.
 
-```mermaid
-flowchart LR
-    RAW["raw inputs<br/>{ params, query, body, headers }"]
+![Each stage reads the whole accumulated context and adds one layer to it](./img/context-accumulation.svg)
 
-    subgraph STAGE["sanitizeInputs stage"]
-        direction LR
-        SP["slice sanitizer<br/>params ✓"]
-        SB["slice sanitizer<br/>body ✓"]
-    end
+## 5. Composition with `HTPipe`
 
-    BOUNDARY{{"stage boundary:<br/>UNSAFE_SLICES deleted"}}
+`HTPipe(...)` merges reusable fragments — "lift the user," "sanitize
+these slices," "load the Thing and require ownership" — into one complete
+handler. The merge is **stage by stage, not end to end**: at runtime, each
+lifecycle stage sweeps left-to-right across every input that declares it,
+threading the accumulating context through; only then does the request
+wrap back to the start of the pipe for the next stage.
 
-    SAFE["ctx.inputs = { params, body }<br/>typed, validated"]
-    GONE(["query, headers: gone —<br/>never reach preAuthorize or beyond;<br/>referencing them is a compile error"])
+![A single request sweeps the whole pipe once per lifecycle stage, wrapping back to the start of the pipe between stages](./img/htpipe-composition.svg)
 
-    RAW --> SP
-    SP -->|"sanitized: { params }<br/>+ raw remainder via UNSAFE_SLICES"| SB
-    SB -->|"sanitized: { params, body }<br/>+ raw remainder"| BOUNDARY
-    BOUNDARY --> SAFE
-    BOUNDARY -.-> GONE
-```
+Per-stage chaining rules, for the curious: `sanitizeInputs` and
+`redactResponse` chain output→input (so redactors stack); loaders and
+authorizers merge their object contributions (right wins on a key clash);
+`execute` runs both and keeps the right result. And
+`finishPipe(pipe, handler)` finishes the dominant authoring shape — one
+shared pipe plus one endpoint-specific trailing handler — with the
+trailing handler's context types inferred from the pipe, so its callbacks
+need zero annotations.
 
-Want a raw slice through anyway? Say so explicitly — `{ query: (q) => q }`
-is a visible, greppable decision instead of a silent default.
+## 6. Adapters
+
+The middle is framework-free; only the edges know what framework you're
+on. **Endpoint adapters** (~100 lines each) canonicalize the raw request
+on the way in and translate the outcome on the way out. **Stage
+factories** — Zod for validation, Mongoose for loading and redaction,
+role/assignee helpers for authorization — emit fragments for one specific
+stage. The same handler object runs unchanged under any of them.
+
+![Endpoint adapters wrap the handler's edges; stage factories plug fragments into single stages](./img/adapters.svg)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # HipThrusTS, visually
 
-Six views that explain how HipThrusTS works and why it exists:
+Seven views that explain how HipThrusTS works and why it exists:
 
 1. [The lifecycle](#1-the-lifecycle) — the eight stages and how flow
    control moves through them
@@ -12,8 +12,11 @@ Six views that explain how HipThrusTS works and why it exists:
 4. [The context only grows](#4-the-context-only-grows) — how every stage
    layers its contribution onto what came before
 5. [Composition with `HTPipe`](#5-composition-with-htpipe) — one request
-   sweeping the whole pipe stage by stage
-6. [Adapters](#6-adapters) — thin edges around a framework-free middle
+   sweeping the whole pipe stage by stage, with each merged stage's typed
+   output exposed for further composition
+6. [Stage dependencies are type-checked](#6-stage-dependencies-are-type-checked)
+   — a stage whose input can't be satisfied upstream is a compile error
+7. [Adapters](#7-adapters) — thin edges around a framework-free middle
 
 Simple flows are Mermaid (GitHub renders it natively, and it's reviewed in
 the same diff as the code it describes). The spatial ones — the growing
@@ -157,7 +160,13 @@ lifecycle stage sweeps left-to-right across every input that declares it,
 threading the accumulating context through; only then does the request
 wrap back to the start of the pipe for the next stage.
 
-![A single request sweeps the whole pipe once per lifecycle stage, wrapping back to the start of the pipe between stages](./img/htpipe-composition.svg)
+![A single request sweeps the whole pipe once per lifecycle stage, wrapping back to the start of the pipe between stages; each merged stage's typed context output is exposed on the right](./img/htpipe-composition.svg)
+
+Note the arrows coming *out* on the right: the merge produces a real
+stage per row, whose output — in types and at runtime — is the previous
+stage's context plus this stage's combined contributions. That makes the
+composed handler a fragment like any other: an `HTPipe` result can be an
+input to another `HTPipe`.
 
 Per-stage chaining rules, for the curious: `sanitizeInputs` and
 `redactResponse` chain output→input (so redactors stack); loaders and
@@ -168,13 +177,25 @@ shared pipe plus one endpoint-specific trailing handler — with the
 trailing handler's context types inferred from the pipe, so its callbacks
 need zero annotations.
 
-## 6. Adapters
+## 6. Stage dependencies are type-checked
+
+The accumulation and composition above aren't just runtime behavior —
+they're carried in the types. Every stage's context parameter declares
+what it needs, and a handler (or pipe) whose upstream stages can't supply
+a declared key is rejected at compile time with a named
+`HipDepNotMet<'stage', 'key'>` marker, so the endpoint can't be wired up
+at all.
+
+![Side by side: a pipe whose loadResources provides ctx.thing compiles; the same finalAuthorize without any loadResources is a type error](./img/stage-dep-typing.svg)
+
+## 7. Adapters
 
 The middle is framework-free; only the edges know what framework you're
 on. **Endpoint adapters** (~100 lines each) canonicalize the raw request
 on the way in and translate the outcome on the way out. **Stage
-factories** — Zod for validation, Mongoose for loading and redaction,
-role/assignee helpers for authorization — emit fragments for one specific
-stage. The same handler object runs unchanged under any of them.
+factories** — Zod for validating inputs and redacting responses against
+schemas, Mongoose for loading, role/assignee helpers for authorization —
+emit fragments for one specific stage. The same handler object runs
+unchanged under any of them.
 
 ![Endpoint adapters wrap the handler's edges; stage factories plug fragments into single stages](./img/adapters.svg)

--- a/docs/img/adapters.svg
+++ b/docs/img/adapters.svg
@@ -1,0 +1,139 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 780" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+  <defs>
+    <marker id="aBlue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#4493f8"/>
+    </marker>
+    <marker id="aGray" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#768390"/>
+    </marker>
+    <marker id="aGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#2ea043"/>
+    </marker>
+    <marker id="aRed" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#f85149"/>
+    </marker>
+    <marker id="aPurple" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#a371f7"/>
+    </marker>
+    <marker id="aPink" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#db61a2"/>
+    </marker>
+    <marker id="aAmber" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#d29922"/>
+    </marker>
+  </defs>
+
+  <text x="40" y="42" font-size="19" font-weight="600" fill="#768390">Three kinds of adapters — none of them touch your handler's logic</text>
+
+  <!-- ===== Left: framework raw shapes ===== -->
+  <g font-size="14.5" font-weight="600" fill="#4493f8">
+    <rect x="40" y="120" width="230" height="56" rx="9" fill="#4493f81f" stroke="#4493f8" stroke-width="1.5"/>
+    <text x="56" y="144">Express</text>
+    <text x="56" y="164" font-size="12.5" font-weight="400">(req, res)</text>
+    <rect x="40" y="210" width="230" height="56" rx="9" fill="#4493f81f" stroke="#4493f8" stroke-width="1.5"/>
+    <text x="56" y="234">tRPC</text>
+    <text x="56" y="254" font-size="12.5" font-weight="400">({ input, ctx })</text>
+    <rect x="40" y="300" width="230" height="56" rx="9" fill="#4493f81f" stroke="#4493f8" stroke-width="1.5"/>
+    <text x="56" y="324">Hono</text>
+    <text x="56" y="344" font-size="12.5" font-weight="400">(c)</text>
+    <rect x="40" y="390" width="230" height="56" rx="9" fill="#4493f81f" stroke="#4493f8" stroke-width="1.5"/>
+    <text x="56" y="414">Fastify · Next.js</text>
+    <text x="56" y="434" font-size="12.5" font-weight="400">(request, reply / NextRequest)</text>
+  </g>
+  <text x="155" y="102" font-size="13" fill="#768390" text-anchor="middle">every framework's raw shape differs…</text>
+
+  <!-- Arrows frameworks -> adapter-in -->
+  <g stroke="#4493f8" stroke-width="2" marker-end="url(#aBlue)">
+    <line x1="270" y1="148" x2="314" y2="185"/>
+    <line x1="270" y1="238" x2="314" y2="250"/>
+    <line x1="270" y1="328" x2="314" y2="315"/>
+    <line x1="270" y1="418" x2="314" y2="380"/>
+  </g>
+
+  <!-- ===== Adapter (in) band ===== -->
+  <rect x="314" y="150" width="146" height="280" rx="9" fill="#76839014" stroke="#768390" stroke-width="1.5"/>
+  <g font-size="12.5" fill="#768390" text-anchor="middle">
+    <text x="386" y="180" font-weight="600" font-size="13.5">endpoint adapter</text>
+    <text x="386" y="198" font-weight="600" font-size="13.5">(in)</text>
+    <text x="386" y="228" font-family="Consolas, monospace" font-size="11.5">toExpressHandler</text>
+    <text x="386" y="246" font-family="Consolas, monospace" font-size="11.5">toTrpcProcedure</text>
+    <text x="386" y="264" font-family="Consolas, monospace" font-size="11.5">toHonoHandler …</text>
+    <text x="386" y="300">canonicalizes to</text>
+    <text x="386" y="320" font-family="Consolas, monospace" font-size="11.5">{ params, query,</text>
+    <text x="386" y="338" font-family="Consolas, monospace" font-size="11.5">body, headers }</text>
+  </g>
+  <line x1="452" y1="250" x2="514" y2="222" stroke="#768390" stroke-width="2.5" marker-end="url(#aGray)"/>
+
+  <!-- ===== Center: the handler card ===== -->
+  <rect x="520" y="90" width="310" height="470" rx="12" fill="#2ea0430d" stroke="#2ea043" stroke-width="2"/>
+  <text x="675" y="122" font-size="16" font-weight="600" fill="#2ea043" text-anchor="middle">your handler</text>
+  <text x="675" y="142" font-size="12" fill="#768390" text-anchor="middle">plain object · framework-free · portable</text>
+
+  <g font-size="13.5" fill="#768390" text-anchor="middle">
+    <rect x="540" y="160" width="270" height="34" rx="8" fill="none" stroke="#768390" stroke-width="1.2" stroke-dasharray="3 3"/>
+    <text x="675" y="182" font-style="italic">extractAmbient</text>
+    <rect x="540" y="204" width="270" height="34" rx="8" fill="none" stroke="#768390" stroke-width="1.2" stroke-dasharray="3 3"/>
+    <text x="675" y="226" font-style="italic">extractInputs</text>
+    <rect x="540" y="248" width="270" height="34" rx="8" fill="#76839014" stroke="#768390" stroke-width="1.4"/>
+    <text x="675" y="270" font-weight="600">sanitizeInputs</text>
+    <rect x="540" y="292" width="270" height="34" rx="8" fill="#76839014" stroke="#768390" stroke-width="1.4"/>
+    <text x="675" y="314" font-weight="600">preAuthorize</text>
+    <rect x="540" y="336" width="270" height="34" rx="8" fill="none" stroke="#768390" stroke-width="1.2" stroke-dasharray="3 3"/>
+    <text x="675" y="358" font-style="italic">loadResources</text>
+    <rect x="540" y="380" width="270" height="34" rx="8" fill="#76839014" stroke="#768390" stroke-width="1.4"/>
+    <text x="675" y="402" font-weight="600">finalAuthorize</text>
+    <rect x="540" y="424" width="270" height="34" rx="8" fill="#76839014" stroke="#768390" stroke-width="1.4"/>
+    <text x="675" y="446" font-weight="600">execute</text>
+    <rect x="540" y="468" width="270" height="34" rx="8" fill="#76839014" stroke="#768390" stroke-width="1.4"/>
+    <text x="675" y="490" font-weight="600">redactResponse</text>
+  </g>
+  <text x="675" y="536" font-size="11.5" fill="#768390" text-anchor="middle">solid = required (missing one = compile error) · dashed = optional</text>
+
+  <!-- Outcomes out of the card -->
+  <line x1="600" y1="560" x2="600" y2="606" stroke="#2ea043" stroke-width="2.5" marker-end="url(#aGreen)"/>
+  <text x="592" y="590" font-size="12" fill="#2ea043" text-anchor="end">safe response</text>
+  <line x1="760" y1="560" x2="760" y2="606" stroke="#f85149" stroke-width="2.5" stroke-dasharray="6 5" marker-end="url(#aRed)"/>
+  <text x="770" y="590" font-size="12" fill="#f85149">HipError, from any stage</text>
+
+  <!-- ===== Adapter (out) band ===== -->
+  <rect x="450" y="612" width="450" height="76" rx="9" fill="#76839014" stroke="#768390" stroke-width="1.5"/>
+  <g font-size="12.5" fill="#768390" text-anchor="middle">
+    <text x="675" y="636" font-weight="600" font-size="13.5">endpoint adapter (out) — translates the outcome</text>
+    <text x="675" y="656" font-family="Consolas, monospace" font-size="11.5">res.status(403).json · TRPCError('FORBIDDEN')</text>
+    <text x="675" y="674" font-family="Consolas, monospace" font-size="11.5">c.json(body, 404) · reply.code(404) — never a stack trace</text>
+  </g>
+
+  <!-- ===== Right: stage-fragment factories ===== -->
+  <text x="1065" y="102" font-size="13" fill="#768390" text-anchor="middle">…and stage factories plug into single stages</text>
+
+  <g>
+    <rect x="890" y="170" width="350" height="72" rx="9" fill="#a371f71f" stroke="#a371f7" stroke-width="1.5"/>
+    <text x="906" y="194" font-size="14" font-weight="600" fill="#a371f7">hipthrusts/zod — schema validation</text>
+    <text x="906" y="214" font-size="11.5" font-family="Consolas, monospace" fill="#a371f7">SanitizeInputsSlicesWithZod({ body: Schema })</text>
+    <text x="906" y="232" font-size="11.5" fill="#768390">only validated slices survive the stage</text>
+    <line x1="888" y1="220" x2="816" y2="262" stroke="#a371f7" stroke-width="2" marker-end="url(#aPurple)"/>
+  </g>
+
+  <g>
+    <rect x="890" y="272" width="350" height="72" rx="9" fill="#db61a21f" stroke="#db61a2" stroke-width="1.5"/>
+    <text x="906" y="296" font-size="14" font-weight="600" fill="#db61a2">auth-check helpers</text>
+    <text x="906" y="316" font-size="11.5" font-family="Consolas, monospace" fill="#db61a2">roleCheckersOnRoleKey · assigneeCheckersOnIdKey</text>
+    <text x="906" y="334" font-size="11.5" fill="#768390">reusable authorize fragments</text>
+    <line x1="888" y1="300" x2="816" y2="309" stroke="#db61a2" stroke-width="2" marker-end="url(#aPink)"/>
+    <line x1="888" y1="330" x2="816" y2="393" stroke="#db61a2" stroke-width="2" marker-end="url(#aPink)"/>
+  </g>
+
+  <g>
+    <rect x="890" y="374" width="350" height="90" rx="9" fill="#d299221f" stroke="#d29922" stroke-width="1.5"/>
+    <text x="906" y="398" font-size="14" font-weight="600" fill="#d29922">hipthrusts/mongoose — data model</text>
+    <text x="906" y="418" font-size="11.5" font-family="Consolas, monospace" fill="#d29922">LoadByIdRequiredTo(Model) · FindScoped(...)</text>
+    <text x="906" y="436" font-size="11.5" font-family="Consolas, monospace" fill="#d29922">json-mask redaction helpers</text>
+    <text x="906" y="454" font-size="11.5" fill="#768390">loaders that 404 when required docs are missing</text>
+    <line x1="888" y1="400" x2="816" y2="356" stroke="#d29922" stroke-width="2" marker-end="url(#aAmber)"/>
+    <line x1="888" y1="440" x2="816" y2="483" stroke="#d29922" stroke-width="2" marker-end="url(#aAmber)"/>
+  </g>
+
+  <!-- ===== Bottom caption ===== -->
+  <text x="640" y="740" font-size="14" font-weight="600" fill="#768390" text-anchor="middle">Swap the edges without touching the middle: the same handler object runs under Express, tRPC, Hono, Fastify, or Next.js.</text>
+  <text x="640" y="762" font-size="13" fill="#768390" text-anchor="middle">A new framework is a ~100-line adapter; a new validator or ORM is a factory that emits fragments for one stage.</text>
+</svg>

--- a/docs/img/adapters.svg
+++ b/docs/img/adapters.svg
@@ -107,11 +107,13 @@
   <text x="1065" y="102" font-size="13" fill="#768390" text-anchor="middle">…and stage factories plug into single stages</text>
 
   <g>
-    <rect x="890" y="170" width="350" height="72" rx="9" fill="#a371f71f" stroke="#a371f7" stroke-width="1.5"/>
-    <text x="906" y="194" font-size="14" font-weight="600" fill="#a371f7">hipthrusts/zod — schema validation</text>
+    <rect x="890" y="170" width="350" height="90" rx="9" fill="#a371f71f" stroke="#a371f7" stroke-width="1.5"/>
+    <text x="906" y="194" font-size="14" font-weight="600" fill="#a371f7">hipthrusts/zod — schema in, schema out</text>
     <text x="906" y="214" font-size="11.5" font-family="Consolas, monospace" fill="#a371f7">SanitizeInputsSlicesWithZod({ body: Schema })</text>
-    <text x="906" y="232" font-size="11.5" fill="#768390">only validated slices survive the stage</text>
-    <line x1="888" y1="220" x2="816" y2="262" stroke="#a371f7" stroke-width="2" marker-end="url(#aPurple)"/>
+    <text x="906" y="232" font-size="11.5" font-family="Consolas, monospace" fill="#a371f7">RedactResponseWithZod(ResponseSchema)</text>
+    <text x="906" y="250" font-size="11.5" fill="#768390">only declared fields survive — inbound or outbound</text>
+    <line x1="888" y1="212" x2="816" y2="262" stroke="#a371f7" stroke-width="2" marker-end="url(#aPurple)"/>
+    <path d="M 893 258 C 838 330, 856 432, 822 478" fill="none" stroke="#a371f7" stroke-width="2" marker-end="url(#aPurple)"/>
   </g>
 
   <g>
@@ -124,13 +126,11 @@
   </g>
 
   <g>
-    <rect x="890" y="374" width="350" height="90" rx="9" fill="#d299221f" stroke="#d29922" stroke-width="1.5"/>
-    <text x="906" y="398" font-size="14" font-weight="600" fill="#d29922">hipthrusts/mongoose — data model</text>
-    <text x="906" y="418" font-size="11.5" font-family="Consolas, monospace" fill="#d29922">LoadByIdRequiredTo(Model) · FindScoped(...)</text>
-    <text x="906" y="436" font-size="11.5" font-family="Consolas, monospace" fill="#d29922">json-mask redaction helpers</text>
-    <text x="906" y="454" font-size="11.5" fill="#768390">loaders that 404 when required docs are missing</text>
-    <line x1="888" y1="400" x2="816" y2="356" stroke="#d29922" stroke-width="2" marker-end="url(#aAmber)"/>
-    <line x1="888" y1="440" x2="816" y2="483" stroke="#d29922" stroke-width="2" marker-end="url(#aAmber)"/>
+    <rect x="890" y="380" width="350" height="72" rx="9" fill="#d299221f" stroke="#d29922" stroke-width="1.5"/>
+    <text x="906" y="404" font-size="14" font-weight="600" fill="#d29922">hipthrusts/mongoose — data model</text>
+    <text x="906" y="424" font-size="11.5" font-family="Consolas, monospace" fill="#d29922">LoadByIdRequiredTo(Model) · FindScoped(...)</text>
+    <text x="906" y="442" font-size="11.5" fill="#768390">loaders that 404 when required docs are missing</text>
+    <line x1="888" y1="404" x2="816" y2="356" stroke="#d29922" stroke-width="2" marker-end="url(#aAmber)"/>
   </g>
 
   <!-- ===== Bottom caption ===== -->

--- a/docs/img/context-accumulation.svg
+++ b/docs/img/context-accumulation.svg
@@ -62,7 +62,9 @@
     <text x="1015" y="428" font-size="13.5" fill="#d29922" text-anchor="middle">isEditor: true</text>
     <rect x="920" y="368" width="190" height="34" rx="6" fill="#a371f726" stroke="#a371f7" stroke-width="2.5"/>
     <text x="1015" y="390" font-size="13.5" fill="#a371f7" text-anchor="middle">thing (loaded doc)</text>
-    <text x="1015" y="354" font-size="12.5" font-weight="600" fill="#a371f7" text-anchor="middle">+ what loadResources fetched</text>
+    <rect x="920" y="330" width="190" height="34" rx="6" fill="#a371f726" stroke="#a371f7" stroke-width="2.5"/>
+    <text x="1015" y="352" font-size="13.5" fill="#a371f7" text-anchor="middle">org (thing's owner org)</text>
+    <text x="1015" y="316" font-size="12.5" font-weight="600" fill="#a371f7" text-anchor="middle">+ every key loadResources returned</text>
     <text x="1015" y="556" font-size="13.5" fill="#768390" text-anchor="middle">…after loadResources</text>
   </g>
 
@@ -76,9 +78,11 @@
     <text x="1455" y="428" font-size="13.5" fill="#d29922" text-anchor="middle">isEditor: true</text>
     <rect x="1360" y="368" width="190" height="34" rx="6" fill="#a371f726" stroke="#a371f7" stroke-width="1.5"/>
     <text x="1455" y="390" font-size="13.5" fill="#a371f7" text-anchor="middle">thing (loaded doc)</text>
-    <rect x="1360" y="330" width="190" height="34" rx="6" fill="#db61a226" stroke="#db61a2" stroke-width="2.5"/>
-    <text x="1455" y="352" font-size="13.5" fill="#db61a2" text-anchor="middle">isOwner: true</text>
-    <text x="1455" y="316" font-size="12.5" font-weight="600" fill="#db61a2" text-anchor="middle">+ finalAuthorize's object</text>
+    <rect x="1360" y="330" width="190" height="34" rx="6" fill="#a371f726" stroke="#a371f7" stroke-width="1.5"/>
+    <text x="1455" y="352" font-size="13.5" fill="#a371f7" text-anchor="middle">org (thing's owner org)</text>
+    <rect x="1360" y="292" width="190" height="34" rx="6" fill="#db61a226" stroke="#db61a2" stroke-width="2.5"/>
+    <text x="1455" y="314" font-size="13.5" fill="#db61a2" text-anchor="middle">isOwner: true</text>
+    <text x="1455" y="278" font-size="12.5" font-weight="600" fill="#db61a2" text-anchor="middle">+ finalAuthorize's object</text>
     <text x="1455" y="556" font-size="13.5" fill="#768390" text-anchor="middle">final context</text>
   </g>
 

--- a/docs/img/context-accumulation.svg
+++ b/docs/img/context-accumulation.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1700 480" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+  <defs>
+    <marker id="arrGray" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#768390"/>
+    </marker>
+  </defs>
+
+  <text x="40" y="40" font-size="20" font-weight="600" fill="#768390">The context only ever grows — each stage reads everything before it, then layers on its contribution</text>
+
+  <g transform="translate(0,-150)">
+  <!-- ===== Stage boxes on the spine (y=465 center) ===== -->
+  <g font-size="15" font-weight="600" text-anchor="middle">
+    <rect x="280" y="443" width="150" height="44" rx="8" fill="#76839018" stroke="#768390" stroke-width="1.5"/>
+    <text x="355" y="471" fill="#768390">preAuthorize</text>
+    <rect x="720" y="443" width="150" height="44" rx="8" fill="#76839018" stroke="#768390" stroke-width="1.5"/>
+    <text x="795" y="471" fill="#768390">loadResources</text>
+    <rect x="1160" y="443" width="150" height="44" rx="8" fill="#76839018" stroke="#768390" stroke-width="1.5"/>
+    <text x="1235" y="471" fill="#768390">finalAuthorize</text>
+  </g>
+
+  <!-- ===== Spine arrows ===== -->
+  <g stroke="#768390" stroke-width="2" marker-end="url(#arrGray)">
+    <line x1="230" y1="465" x2="272" y2="465"/>
+    <line x1="430" y1="465" x2="472" y2="465"/>
+    <line x1="670" y1="465" x2="712" y2="465"/>
+    <line x1="870" y1="465" x2="912" y2="465"/>
+    <line x1="1110" y1="465" x2="1152" y2="465"/>
+    <line x1="1310" y1="465" x2="1352" y2="465"/>
+    <line x1="1552" y1="465" x2="1590" y2="465"/>
+  </g>
+  <text x="1598" y="450" font-size="14" fill="#768390">execute,</text>
+  <text x="1598" y="468" font-size="14" fill="#768390">redact…</text>
+
+  <!-- ===== Stack S0: initial context ===== -->
+  <g>
+    <rect x="40" y="482" width="190" height="34" rx="6" fill="#4493f826" stroke="#4493f8" stroke-width="1.5"/>
+    <text x="135" y="504" font-size="13.5" fill="#4493f8" text-anchor="middle">ambient · { user }</text>
+    <rect x="40" y="444" width="190" height="34" rx="6" fill="#2ea04326" stroke="#2ea043" stroke-width="1.5"/>
+    <text x="135" y="466" font-size="13.5" fill="#2ea043" text-anchor="middle">inputs · { params, body }</text>
+    <text x="135" y="556" font-size="13.5" font-weight="600" fill="#768390" text-anchor="middle">initial context</text>
+  </g>
+
+  <!-- ===== Stack S1: after preAuthorize ===== -->
+  <g>
+    <rect x="480" y="482" width="190" height="34" rx="6" fill="#4493f826" stroke="#4493f8" stroke-width="1.5"/>
+    <text x="575" y="504" font-size="13.5" fill="#4493f8" text-anchor="middle">ambient · { user }</text>
+    <rect x="480" y="444" width="190" height="34" rx="6" fill="#2ea04326" stroke="#2ea043" stroke-width="1.5"/>
+    <text x="575" y="466" font-size="13.5" fill="#2ea043" text-anchor="middle">inputs · { params, body }</text>
+    <rect x="480" y="406" width="190" height="34" rx="6" fill="#d2992226" stroke="#d29922" stroke-width="2.5"/>
+    <text x="575" y="428" font-size="13.5" fill="#d29922" text-anchor="middle">isEditor: true</text>
+    <text x="575" y="392" font-size="12.5" font-weight="600" fill="#d29922" text-anchor="middle">+ preAuthorize's object</text>
+    <text x="575" y="556" font-size="13.5" fill="#768390" text-anchor="middle">…after preAuthorize</text>
+  </g>
+
+  <!-- ===== Stack S2: after loadResources ===== -->
+  <g>
+    <rect x="920" y="482" width="190" height="34" rx="6" fill="#4493f826" stroke="#4493f8" stroke-width="1.5"/>
+    <text x="1015" y="504" font-size="13.5" fill="#4493f8" text-anchor="middle">ambient · { user }</text>
+    <rect x="920" y="444" width="190" height="34" rx="6" fill="#2ea04326" stroke="#2ea043" stroke-width="1.5"/>
+    <text x="1015" y="466" font-size="13.5" fill="#2ea043" text-anchor="middle">inputs · { params, body }</text>
+    <rect x="920" y="406" width="190" height="34" rx="6" fill="#d2992226" stroke="#d29922" stroke-width="1.5"/>
+    <text x="1015" y="428" font-size="13.5" fill="#d29922" text-anchor="middle">isEditor: true</text>
+    <rect x="920" y="368" width="190" height="34" rx="6" fill="#a371f726" stroke="#a371f7" stroke-width="2.5"/>
+    <text x="1015" y="390" font-size="13.5" fill="#a371f7" text-anchor="middle">thing (loaded doc)</text>
+    <text x="1015" y="354" font-size="12.5" font-weight="600" fill="#a371f7" text-anchor="middle">+ what loadResources fetched</text>
+    <text x="1015" y="556" font-size="13.5" fill="#768390" text-anchor="middle">…after loadResources</text>
+  </g>
+
+  <!-- ===== Stack S3: after finalAuthorize ===== -->
+  <g>
+    <rect x="1360" y="482" width="190" height="34" rx="6" fill="#4493f826" stroke="#4493f8" stroke-width="1.5"/>
+    <text x="1455" y="504" font-size="13.5" fill="#4493f8" text-anchor="middle">ambient · { user }</text>
+    <rect x="1360" y="444" width="190" height="34" rx="6" fill="#2ea04326" stroke="#2ea043" stroke-width="1.5"/>
+    <text x="1455" y="466" font-size="13.5" fill="#2ea043" text-anchor="middle">inputs · { params, body }</text>
+    <rect x="1360" y="406" width="190" height="34" rx="6" fill="#d2992226" stroke="#d29922" stroke-width="1.5"/>
+    <text x="1455" y="428" font-size="13.5" fill="#d29922" text-anchor="middle">isEditor: true</text>
+    <rect x="1360" y="368" width="190" height="34" rx="6" fill="#a371f726" stroke="#a371f7" stroke-width="1.5"/>
+    <text x="1455" y="390" font-size="13.5" fill="#a371f7" text-anchor="middle">thing (loaded doc)</text>
+    <rect x="1360" y="330" width="190" height="34" rx="6" fill="#db61a226" stroke="#db61a2" stroke-width="2.5"/>
+    <text x="1455" y="352" font-size="13.5" fill="#db61a2" text-anchor="middle">isOwner: true</text>
+    <text x="1455" y="316" font-size="12.5" font-weight="600" fill="#db61a2" text-anchor="middle">+ finalAuthorize's object</text>
+    <text x="1455" y="556" font-size="13.5" fill="#768390" text-anchor="middle">final context</text>
+  </g>
+
+  </g>
+
+  <!-- ===== Footnotes ===== -->
+  <text x="40" y="434" font-size="13.5" fill="#768390">authorize stages contribute only when they return an object — returning true passes and adds nothing; false denies (→ 403) and the flow stops.</text>
+  <text x="40" y="458" font-size="13.5" fill="#768390">execute receives the final stack, and redactResponse receives it too (as its 2nd argument) — so redaction can depend on who is asking.</text>
+</svg>

--- a/docs/img/htpipe-composition.svg
+++ b/docs/img/htpipe-composition.svg
@@ -1,0 +1,107 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 880" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+  <defs>
+    <marker id="arrGreen" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#2ea043"/>
+    </marker>
+    <marker id="arrGreenSoft" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#2ea043" opacity="0.45"/>
+    </marker>
+  </defs>
+
+  <!-- Title + legend -->
+  <text x="40" y="52" font-size="19" font-weight="600" fill="#768390">HTPipe(input 1, input 2, input 3) → one handler; each stage sweeps the whole pipe, then wraps back</text>
+  <g>
+    <line x1="900" y1="72" x2="950" y2="72" stroke="#2ea043" stroke-width="3.5"/>
+    <text x="958" y="76" font-size="13" fill="#768390">stage executing, left → right</text>
+    <line x1="900" y1="94" x2="950" y2="94" stroke="#2ea043" stroke-width="2.5" stroke-dasharray="7 6" opacity="0.45"/>
+    <text x="958" y="98" font-size="13" fill="#768390">context carried back to the pipe's start</text>
+  </g>
+
+  <!-- Outer composed-handler box -->
+  <rect x="20" y="110" width="1210" height="700" rx="12" fill="none" stroke="#768390" stroke-width="1.5"/>
+
+  <!-- Fragment column boxes -->
+  <g fill="none" stroke="#768390" stroke-width="1.2" stroke-dasharray="4 4">
+    <rect x="150" y="140" width="220" height="590" rx="10"/>
+    <rect x="470" y="140" width="220" height="590" rx="10"/>
+    <rect x="790" y="140" width="220" height="590" rx="10"/>
+  </g>
+  <g font-size="15" font-weight="600" fill="#768390" text-anchor="middle">
+    <text x="260" y="168">HTPipe input 1</text>
+    <text x="580" y="168">HTPipe input 2</text>
+    <text x="900" y="168">HTPipe input 3</text>
+  </g>
+
+  <!-- ===== Return sweeps (dashed, behind) ===== -->
+  <g fill="none" stroke="#2ea043" stroke-width="2.5" stroke-dasharray="7 6" opacity="0.45" marker-end="url(#arrGreenSoft)">
+    <path d="M 1140 210 A 23.5 23.5 0 0 1 1140 257 H 100 A 24 24 0 0 0 100 305"/>
+    <path d="M 1140 305 A 23.5 23.5 0 0 1 1140 352 H 100 A 24 24 0 0 0 100 400"/>
+    <path d="M 1140 400 A 23.5 23.5 0 0 1 1140 447 H 100 A 24 24 0 0 0 100 495"/>
+    <path d="M 1140 495 A 23.5 23.5 0 0 1 1140 542 H 100 A 24 24 0 0 0 100 590"/>
+    <path d="M 1140 590 A 23.5 23.5 0 0 1 1140 637 H 100 A 24 24 0 0 0 100 685"/>
+  </g>
+
+  <!-- ===== Execution segments (solid) ===== -->
+  <g stroke="#2ea043" stroke-width="3.5">
+    <!-- row 1: sanitizeInputs -->
+    <line x1="40"  y1="210" x2="181" y2="210" marker-end="url(#arrGreen)"/>
+    <line x1="335" y1="210" x2="1140" y2="210"/>
+    <!-- row 2: preAuthorize -->
+    <line x1="100" y1="305" x2="181" y2="305" marker-end="url(#arrGreen)"/>
+    <line x1="335" y1="305" x2="1140" y2="305"/>
+    <!-- row 3: loadResources (inputs 2 and 3 chain) -->
+    <line x1="100" y1="400" x2="501" y2="400" marker-end="url(#arrGreen)"/>
+    <line x1="655" y1="400" x2="821" y2="400" marker-end="url(#arrGreen)"/>
+    <line x1="975" y1="400" x2="1140" y2="400"/>
+    <!-- row 4: finalAuthorize -->
+    <line x1="100" y1="495" x2="501" y2="495" marker-end="url(#arrGreen)"/>
+    <line x1="655" y1="495" x2="1140" y2="495"/>
+    <!-- row 5: execute -->
+    <line x1="100" y1="590" x2="821" y2="590" marker-end="url(#arrGreen)"/>
+    <line x1="975" y1="590" x2="1140" y2="590"/>
+    <!-- row 6: redactResponse, exits -->
+    <line x1="100" y1="685" x2="181" y2="685" marker-end="url(#arrGreen)"/>
+    <line x1="335" y1="685" x2="1236" y2="685" marker-end="url(#arrGreen)"/>
+  </g>
+
+  <!-- Entry / exit labels -->
+  <text x="40" y="192" font-size="13" fill="#768390">raw / unsafe inputs</text>
+  <text x="1226" y="668" font-size="13" fill="#768390" text-anchor="end">safe response</text>
+
+  <!-- Faint stage names near left start for rows whose first pill is far right -->
+  <g font-size="12" fill="#768390" opacity="0.8">
+    <text x="108" y="392">loadResources</text>
+    <text x="108" y="487">finalAuthorize</text>
+    <text x="108" y="582">execute</text>
+  </g>
+
+  <!-- ===== Stage pills ===== -->
+  <g font-size="13.5" font-weight="600" text-anchor="middle">
+    <!-- input 1 -->
+    <rect x="185" y="193" width="150" height="34" rx="17" fill="#2ea04322" stroke="#2ea043" stroke-width="1.8"/>
+    <text x="260" y="215" fill="#2ea043">sanitizeInputs</text>
+    <rect x="185" y="288" width="150" height="34" rx="17" fill="#2ea04322" stroke="#2ea043" stroke-width="1.8"/>
+    <text x="260" y="310" fill="#2ea043">preAuthorize</text>
+    <rect x="185" y="668" width="150" height="34" rx="17" fill="#2ea04322" stroke="#2ea043" stroke-width="1.8"/>
+    <text x="260" y="690" fill="#2ea043">redactResponse</text>
+    <!-- input 2 -->
+    <rect x="505" y="383" width="150" height="34" rx="17" fill="#2ea04322" stroke="#2ea043" stroke-width="1.8"/>
+    <text x="580" y="405" fill="#2ea043">loadResources</text>
+    <rect x="505" y="478" width="150" height="34" rx="17" fill="#2ea04322" stroke="#2ea043" stroke-width="1.8"/>
+    <text x="580" y="500" fill="#2ea043">finalAuthorize</text>
+    <!-- input 3 -->
+    <rect x="825" y="383" width="150" height="34" rx="17" fill="#2ea04322" stroke="#2ea043" stroke-width="1.8"/>
+    <text x="900" y="405" fill="#2ea043">loadResources</text>
+    <rect x="825" y="573" width="150" height="34" rx="17" fill="#2ea04322" stroke="#2ea043" stroke-width="1.8"/>
+    <text x="900" y="595" fill="#2ea043">execute</text>
+  </g>
+
+  <!-- Footnotes -->
+  <g font-size="13" fill="#768390" text-anchor="middle">
+    <text x="625" y="762">a row passes straight through an input that doesn't declare that stage; when two inputs declare it (loadResources here), they chain left → right</text>
+    <text x="625" y="786">any authorize fragment returning false stops the sweep for good → HipForbidden (403)</text>
+  </g>
+
+  <!-- Bottom-of-canvas note -->
+  <text x="625" y="850" font-size="13.5" fill="#768390" text-anchor="middle">the whole pipe finishes each lifecycle stage before the request returns to the start of the pipe for the next one</text>
+</svg>

--- a/docs/img/htpipe-composition.svg
+++ b/docs/img/htpipe-composition.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 880" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1560 880" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
   <defs>
     <marker id="arrGreen" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
       <path d="M0 0 L10 5 L0 10 z" fill="#2ea043"/>
@@ -61,12 +61,30 @@
     <line x1="975" y1="590" x2="1140" y2="590"/>
     <!-- row 6: redactResponse, exits -->
     <line x1="100" y1="685" x2="181" y2="685" marker-end="url(#arrGreen)"/>
-    <line x1="335" y1="685" x2="1236" y2="685" marker-end="url(#arrGreen)"/>
+    <line x1="335" y1="685" x2="1290" y2="685" marker-end="url(#arrGreen)"/>
   </g>
 
-  <!-- Entry / exit labels -->
+  <!-- ===== Per-stage typed context outputs (the composition is a fragment too) ===== -->
+  <g stroke="#2ea043" stroke-width="3" marker-end="url(#arrGreen)">
+    <line x1="1140" y1="210" x2="1290" y2="210"/>
+    <line x1="1140" y1="305" x2="1290" y2="305"/>
+    <line x1="1140" y1="400" x2="1290" y2="400"/>
+    <line x1="1140" y1="495" x2="1290" y2="495"/>
+    <line x1="1140" y1="590" x2="1290" y2="590"/>
+  </g>
+  <g font-size="12.5" fill="#768390">
+    <text x="1300" y="166" font-style="italic">each merged stage's typed</text>
+    <text x="1300" y="184" font-style="italic">context output is exposed:</text>
+    <text x="1300" y="214">safe inputs — typed</text>
+    <text x="1300" y="309">ctx + preAuthorize's objects</text>
+    <text x="1300" y="404">ctx + everything loaded</text>
+    <text x="1300" y="499">ctx + finalAuthorize's objects</text>
+    <text x="1300" y="594">unsafe response</text>
+    <text x="1300" y="689">safe response</text>
+  </g>
+
+  <!-- Entry label -->
   <text x="40" y="192" font-size="13" fill="#768390">raw / unsafe inputs</text>
-  <text x="1226" y="668" font-size="13" fill="#768390" text-anchor="end">safe response</text>
 
   <!-- Faint stage names near left start for rows whose first pill is far right -->
   <g font-size="12" fill="#768390" opacity="0.8">
@@ -103,5 +121,6 @@
   </g>
 
   <!-- Bottom-of-canvas note -->
-  <text x="625" y="850" font-size="13.5" fill="#768390" text-anchor="middle">the whole pipe finishes each lifecycle stage before the request returns to the start of the pipe for the next one</text>
+  <text x="780" y="846" font-size="13.5" fill="#768390" text-anchor="middle">each stage's output — in types and at runtime — is shaped by the previous stage's context plus this stage's merged contributions,</text>
+  <text x="780" y="870" font-size="13.5" fill="#768390" text-anchor="middle">so the composed handler is itself a fragment: an HTPipe result can be an input to another HTPipe</text>
 </svg>

--- a/docs/img/stage-dep-typing.svg
+++ b/docs/img/stage-dep-typing.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 540" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+  <defs>
+    <marker id="dGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#2ea043"/>
+    </marker>
+  </defs>
+
+  <text x="40" y="42" font-size="19" font-weight="600" fill="#768390">Every stage declares the context it needs — a composition that can't supply it will not compile</text>
+
+  <!-- ===== Left panel: compiles ===== -->
+  <rect x="40" y="80" width="570" height="360" rx="12" fill="#2ea04308" stroke="#2ea043" stroke-width="1.8"/>
+  <text x="70" y="112" font-size="15" font-weight="600" fill="#2ea043">✓ compiles</text>
+
+  <rect x="90" y="136" width="470" height="78" rx="9" fill="#76839010" stroke="#768390" stroke-width="1.4"/>
+  <text x="110" y="162" font-size="13" font-weight="600" fill="#768390">loadResources</text>
+  <text x="110" y="182" font-size="12" font-family="Consolas, monospace" fill="#768390">async (ctx) => ({ thing: await Thing.findById(…) })</text>
+  <rect x="110" y="192" width="150" height="0" fill="none"/>
+  <rect x="386" y="188" width="158" height="22" rx="11" fill="#a371f726" stroke="#a371f7" stroke-width="1.5"/>
+  <text x="465" y="203" font-size="11.5" font-weight="600" fill="#a371f7" text-anchor="middle">provides ctx.thing</text>
+
+  <line x1="465" y1="214" x2="465" y2="252" stroke="#2ea043" stroke-width="2.5" marker-end="url(#dGreen)"/>
+
+  <rect x="90" y="256" width="470" height="78" rx="9" fill="#76839010" stroke="#768390" stroke-width="1.4"/>
+  <text x="110" y="282" font-size="13" font-weight="600" fill="#768390">finalAuthorize</text>
+  <text x="110" y="302" font-size="12" font-family="Consolas, monospace" fill="#768390">(ctx) => ctx.thing.ownerId === ctx.ambient.user.id</text>
+  <rect x="396" y="308" width="148" height="22" rx="11" fill="none" stroke="#a371f7" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <text x="470" y="323" font-size="11.5" font-weight="600" fill="#a371f7" text-anchor="middle">needs ctx.thing</text>
+
+  <text x="90" y="376" font-size="13" fill="#2ea043" font-weight="600">✓ satisfied by the stage above —</text>
+  <text x="90" y="396" font-size="13" fill="#768390">and finalAuthorize's ctx parameter is fully typed: it knows thing's shape</text>
+
+  <!-- ===== Right panel: type error ===== -->
+  <rect x="670" y="80" width="570" height="360" rx="12" fill="#f8514908" stroke="#f85149" stroke-width="1.8"/>
+  <text x="700" y="112" font-size="15" font-weight="600" fill="#f85149">✗ type error — never ships</text>
+
+  <rect x="720" y="136" width="470" height="78" rx="9" fill="none" stroke="#768390" stroke-width="1.4" stroke-dasharray="5 4"/>
+  <text x="955" y="172" font-size="13" font-style="italic" fill="#768390" text-anchor="middle">no loadResources anywhere in the pipe</text>
+  <text x="955" y="192" font-size="12" font-style="italic" fill="#768390" text-anchor="middle">nothing upstream produces thing</text>
+
+  <rect x="720" y="256" width="470" height="78" rx="9" fill="#76839010" stroke="#768390" stroke-width="1.4"/>
+  <text x="740" y="282" font-size="13" font-weight="600" fill="#768390">finalAuthorize</text>
+  <text x="740" y="302" font-size="12" font-family="Consolas, monospace" fill="#768390">(ctx) => <tspan fill="#f85149" font-weight="600">ctx.thing</tspan>.ownerId === ctx.ambient.user.id</text>
+  <path d="M 792 308 q 4 5 8 0 q 4 -5 8 0 q 4 5 8 0 q 4 -5 8 0 q 4 5 8 0 q 4 -5 8 0 q 4 5 8 0" fill="none" stroke="#f85149" stroke-width="1.6"/>
+  <rect x="1026" y="308" width="148" height="22" rx="11" fill="none" stroke="#f85149" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <text x="1100" y="323" font-size="11.5" font-weight="600" fill="#f85149" text-anchor="middle">needs ctx.thing</text>
+
+  <text x="720" y="376" font-size="12.5" font-family="Consolas, monospace" fill="#f85149">HipDepNotMet&lt;'finalAuthorize', 'thing'&gt;</text>
+  <text x="720" y="398" font-size="13" fill="#768390">the composition's type is rejected — the adapter won't accept the handler,</text>
+  <text x="720" y="418" font-size="13" fill="#768390">so the endpoint cannot be wired up until the dependency is met</text>
+
+  <!-- ===== Footnote ===== -->
+  <text x="40" y="482" font-size="13.5" fill="#768390">The same dependency typing powers inference: every stage's ctx parameter knows exactly which keys — and which types — earlier stages produced.</text>
+  <text x="40" y="506" font-size="13.5" fill="#768390">It applies across HTPipe fragments too: a fragment consuming a key no earlier fragment provides poisons the composed type the same way.</text>
+</svg>


### PR DESCRIPTION
## What does this PR do?

Adds a new `docs/architecture.md` file with seven detailed views explaining how HipThrusTS works, including:

1. **The lifecycle** — the eight stages and flow control through them
2. **Failure routing** — how each stage's failures map to client-safe responses
3. **From raw request to initial context** — trusted vs. untrusted data handling
4. **The context only grows** — how each stage layers onto prior context
5. **Composition with `HTPipe`** — stage-by-stage request sweeping and merging
6. **Stage dependencies are type-checked** — compile-time dependency validation
7. **Adapters** — the framework-agnostic middle and thin edges

The documentation includes:
- Mermaid flowcharts for the lifecycle and failure routing (rendered natively by GitHub)
- Four hand-drawn SVGs in `docs/img/` for spatial concepts (context accumulation, HTPipe composition, stage dependency typing, and the adapter surface)
- All SVGs use theme-neutral colors for correct rendering in both GitHub light and dark modes

Also updates `README.md` to point readers to the new architecture documentation.

## Checklist

- [x] No code changes — documentation only
- [x] Docs added (new `docs/architecture.md` and supporting SVG diagrams)
- [x] README updated with link to architecture docs

https://claude.ai/code/session_01NF4AdbjdQxbyDUxTHbE9Nx