### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (before 1.0, minor releases could contain breaking changes).
 
-## [Unreleased]
+## [1.1.0] - 2026-07-19
 
 ### Added
 
@@ -319,7 +319,8 @@ dogfooding-feedback fixes into the 0.12.0 release._
 - Initial public releases: Express + Mongoose oriented handler classes with
   the mandatory-stage lifecycle.
 
-[1.0.0]: https://github.com/trycatchal/hipthrusts/compare/e7205a2...main
+[1.1.0]: https://github.com/trycatchal/hipthrusts/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/trycatchal/hipthrusts/compare/e7205a2...v1.0.0
 [0.13.0]: https://github.com/trycatchal/hipthrusts/compare/28fd759...e7205a2
 [0.11.0]: https://github.com/trycatchal/hipthrusts/commit/c0fee82
 [0.10.0]: https://github.com/trycatchal/hipthrusts/commit/beb8b0d

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hipthrusts",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/trycatchal/hipthrusts.git"


### PR DESCRIPTION
## What does this PR do?

Finalizes the **1.1.0** release. Version + changelog only — no source changes (the features already merged via #114).

- `package.json`: `1.0.0` → `1.1.0`
- `CHANGELOG.md`: roll `[Unreleased]` into `## [1.1.0] - 2026-07-19` and add the `[1.1.0]` compare link; also point the `[1.0.0]` link at the `v1.0.0` tag instead of the drifting `main` ref.

## Why minor (1.1.0)

This release adds the backend-neutral `hipthrusts/ctx-ref` subpath — new public API — so a patch would be dishonest. Everything shipped is backward compatible: the `extractAmbient` 422→500 fix (a misclassification correction on undocumented edge behavior), the auth-gate docs, the new subpath, and the `@deprecated` markers on the `hipthrusts/mongoose` re-exports (which remain functional).

## After merge

Tag the merge commit on `main` and push the tag to trigger the Release workflow (`npm publish --provenance`):

```bash
git checkout main && git pull origin main
git tag v1.1.0
git push origin v1.1.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HoGnocn8JV1iaXxdnwA5ir

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoGnocn8JV1iaXxdnwA5ir)_