### PR TITLE
Publish via npm Trusted Publishing (OIDC), drop stored token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  # OIDC token for npm Trusted Publishing — no long-lived NPM_TOKEN secret.
   id-token: write
 
 jobs:
@@ -22,7 +23,9 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm test
-      # prepublishOnly runs clean + build + check:exports + smoke
-      - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Trusted Publishing (OIDC) needs npm >= 11.5.1; Node 22 ships npm 10.
+      - run: npm install -g npm@latest
+      # prepublishOnly runs clean + build + check:exports + smoke.
+      # No NODE_AUTH_TOKEN and no --provenance: with Trusted Publishing npm
+      # authenticates via OIDC and attaches provenance automatically.
+      - run: npm publish --access public


### PR DESCRIPTION
## What does this PR do?

Switches the Release workflow from a long-lived `NPM_TOKEN` secret to **npm Trusted Publishing (OIDC)** — the approach npm recommends for CI/CD, and the reason the 1.1.0 publish failed with `ENEEDAUTH` (no valid token was configured).

With Trusted Publishing there is no token to store, rotate, or leak: GitHub Actions presents a short-lived OIDC identity that npm verifies against a publisher you register on the package.

## Changes to `release.yml`

- Remove the `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env — no token needed.
- Remove `--provenance` — Trusted Publishing attaches provenance automatically.
- Add `npm install -g npm@latest` — OIDC publishing requires npm ≥ 11.5.1, but the pinned Node 22 ships npm 10.
- `permissions.id-token: write` was already present (nothing to add).

## Required one-time setup (npm side, admin)

On npmjs.com → the `hipthrusts` package → **Settings → Trusted Publisher**, add a GitHub Actions publisher:
- Organization / user: `trycatchal`
- Repository: `hipthrusts`
- Workflow filename: `release.yml`
- Environment: *(leave blank)*

## Releasing 1.1.0 after this merges

The existing `v1.1.0` tag points at a commit that still has the *old* workflow (tag-triggered runs use the workflow file as it existed at the tagged commit). So after merging this and configuring the npm publisher, move the tag to include the fix:

```bash
git checkout main && git pull origin main
git push origin :refs/tags/v1.1.0   # delete remote tag
git tag -f v1.1.0                    # re-point at main HEAD (has the fix + version 1.1.0)
git push origin v1.1.0
```

Nothing was published on the failed run, so `1.1.0` is still free to claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HoGnocn8JV1iaXxdnwA5ir

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoGnocn8JV1iaXxdnwA5ir)_